### PR TITLE
Add JWT CLI tools and documentation

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_10_install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_10_install-packages.sh.tmpl
@@ -21,6 +21,7 @@ taps=(
 	"gh"
 	"helm"
 	"jq"
+	"mike-engel/jwt-cli/jwt-cli"
 	"kubernetes-cli"
 	"lnav"
 	"mas"

--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -7,6 +7,28 @@
   4. Once editing is complete, prompt the user to apply the chezmoi changes
 * zsh aliases are managed by chezmoi in ~/.local/share/chezmoi/home/dot_zsh_aliases.tmpl
 
+## Scripts
+### Working with JWTs
+Decode a JWT:
+```shell
+jwt decode jwt_string
+```
+
+Decode a JWT as a JSON string:
+```shell
+jwt decode [-j|--json] jwt_string
+```
+
+Encode a JSON string to a JWT:
+```shell
+jwt encode [-A|--alg] HS256 [-S|--secret] 1234567890 'json_string'
+```
+
+Encode key pair payload to JWT:
+```shell
+jwt encode [-A|--alg] HS256 [-S|--secret] 1234567890 [-P|--payload] key=value
+```
+
 ## Github CLI (`gh`) tips
 `gh` only supports adding a comment to a pull request (https://cli.github.com/manual/gh_pr_comment).  If asked to create, update, delete or reply to a PR review comment, prefer using `gh api` (https://cli.github.com/manual/gh_api) and the REST API for review commments (https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#about-pull-request-review-comments)
 

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -200,6 +200,10 @@ source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 # shell integration for fzf
 source <(fzf --zsh)
 
+if hash jwt > /dev/null; then
+  source <(jwt completion zsh)
+fi
+
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
 


### PR DESCRIPTION
## Summary
- Add jwt-cli package to Homebrew installations
- Add shell completions for jwt-cli in zsh configuration
- Document JWT encode/decode commands in CLAUDE.md template
- Provides convenient CLI tools for working with JSON Web Tokens

## Test plan
- [ ] Run chezmoi apply to install jwt-cli via Homebrew
- [ ] Verify shell completions work for jwt-cli commands
- [ ] Test JWT decode functionality with a sample JWT
- [ ] Test JWT encode functionality with sample payload
- [ ] Verify CLAUDE.md is updated with JWT documentation

🤖 Generated with [Claude Code](https://claude.ai/code)