### PR TITLE
Fix zsh initialization error from asdf Java check

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -220,7 +220,7 @@ eval "$(pyenv init -)"
 
 export PATH="$PATH":"$HOME/.pub-cache/bin"
 
-export JAVA_HOME=$(asdf where java)
+export JAVA_HOME=$(asdf where java 2>/dev/null)
 
 # Initialize rbenv if it exists
 if command -v rbenv >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Suppress stderr output from `asdf where java` command in .zshrc
- Fixes Powerlevel10k warning about console output during initialization

## Details
When `asdf` doesn't have a Java version set, it outputs an error message to stderr during shell initialization. This causes Powerlevel10k to display a warning about console output during the instant prompt phase.

The fix redirects stderr to `/dev/null` to suppress this message while still allowing the JAVA_HOME variable to be set if Java is properly configured.

## Test plan
- [x] Open a new terminal session
- [x] Verify no console output warning from Powerlevel10k
- [x] Confirm JAVA_HOME is still set correctly when Java is configured in asdf

🤖 Generated with [Claude Code](https://claude.ai/code)