### PR TITLE
Add NPM configuration for GitHub packages

### DIFF
--- a/home/private_dot_npmrc.tmpl
+++ b/home/private_dot_npmrc.tmpl
@@ -1,0 +1,2 @@
+@dnastack:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken={{ onepasswordRead .secrets.github.tokens.maven_settings }}


### PR DESCRIPTION
## Summary
- Configure @dnastack scoped packages to use GitHub npm registry (https://npm.pkg.github.com/)
- Add `.npmrc` configuration file as a chezmoi template
- Integrate 1Password for secure npm authentication token management using the existing Maven settings token

## Test plan
- [ ] Run `chezmoi apply` to apply the template
- [ ] Verify `.npmrc` is created in home directory with correct registry configuration
- [ ] Test installing a @dnastack scoped package to confirm authentication works
- [ ] Ensure 1Password integration properly retrieves the auth token

🤖 Generated with [Claude Code](https://claude.ai/code)