### PR TITLE
Add 1Password plugin configuration for GitHub CLI

### DIFF
--- a/.op/plugins/gh.json
+++ b/.op/plugins/gh.json
@@ -1,0 +1,15 @@
+{
+	"account_id": "JYFI4AQLPZGW5NR3DYA7CSXDU4",
+	"entrypoint": [
+		"gh"
+	],
+	"credentials": [
+		{
+			"plugin": "github",
+			"credential_type": "personal_access_token",
+			"usage_id": "personal_access_token",
+			"vault_id": "3ohhb3u6gardrzv65oxidkfcpi",
+			"item_id": "rsjeifhmvn43ghruv5sp3l5kwq"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Configure gh CLI to use 1Password for secure authentication
- Add `.op/plugins/gh.json` configuration file to enable 1Password integration
- Store GitHub personal access token securely in 1Password vault
- Enable seamless gh CLI authentication without exposing credentials in plain text

## Test plan
- [ ] Verify 1Password is installed and configured
- [ ] Ensure GitHub personal access token is stored in the referenced 1Password vault
- [ ] Test `gh auth status` to confirm authentication works through 1Password
- [ ] Run sample gh commands (e.g., `gh repo list`) to verify integration

🤖 Generated with [Claude Code](https://claude.ai/code)