### PR TITLE
Replace asdf with mise for runtime version management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,11 @@
 
 ### Script Execution Order
 Scripts in `home/.chezmoiscripts/` run in numbered order, all `run_onchange_before`:
-* `01_mac_setup` — Dock prefs, NVM dir, macOS updates (work only)
+* `01_mac_setup` — Dock prefs, macOS updates (work only)
 * `10_install-packages` — Homebrew taps + `brew bundle` (common + device-specific)
-* `11_install_python` — pipx, poetry
-* `12_install_java` — asdf java plugin, JDK 21/24 (work only)
-* `13_install_python` — asdf python plugin, Python 3.13.1 (work only)
+* `11_install_python` — uv tool management
+* `12_install_java` — mise java, JDK 21/24 (work only)
+* `13_install_python` — mise python, Python 3.13 (work only)
 
 ### Template Conventions
 * `{{ if .work_device }}` / `{{ if .personal_device }}` gate sections
@@ -47,7 +47,7 @@ Scripts in `home/.chezmoiscripts/` run in numbered order, all `run_onchange_befo
 * Data accessed as `.packages.*`, `.secrets.*`, `.email`, `.chezmoi.os`
 
 ### Key Managed Files
-* `dot_zshrc.tmpl` — main shell config (Oh-My-Zsh, Powerlevel10k, asdf, nvm, pyenv, fzf)
+* `dot_zshrc.tmpl` — main shell config (Oh-My-Zsh, Powerlevel10k, mise, fzf)
 * `dot_zsh_aliases.tmpl` — aliases: chezmoi (`cm*`), kubernetes (`k*`), 1Password gh plugin
 * `dot_zsh_claude_code_functions.tmpl` — `ccs` (suggest), `cce` (explain), `ccef` (explain failure)
 * `dot_gitconfig.tmpl` — git config with 1Password SSH signing, Beyond Compare merge tool

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ During `chezmoi apply` you will be prompted for three values (cached after first
 
 > **Note:** The reversed scroll direction preference is written immediately but requires a
 > **logout or restart** to take effect.
-- Install pipx
-- For work devices: enable automatic macOS updates, install Java 21 + 24 and Python 3.13.1 via asdf
+- Configure uv tool management
+- For work devices: enable automatic macOS updates, install Java 21 + 24 and Python 3.13 via mise
 
 **Work devices — second apply:** The first apply skips 1Password-backed secrets (NPM token,
 Maven credentials) because the `op` CLI isn't available yet. After the first apply installs

--- a/docs/plans/2026-02-28-asdf-mise-migration-design.md
+++ b/docs/plans/2026-02-28-asdf-mise-migration-design.md
@@ -1,0 +1,100 @@
+# Replace asdf with mise for runtime version management
+
+## Problem
+
+The dotfiles use two runtime managers: `asdf` (Java, Python) and `mise` (Node.js via script 14). This split is confusing and redundant. mise is a faster, single-binary replacement that already handles Node.js in this repo. asdf should be removed entirely.
+
+## Decision
+
+Migrate all asdf-managed runtimes (Java, Python) to mise and remove every trace of asdf from the codebase. Replace the p10k `asdf` prompt segment with a custom `mise` segment based on the dagadbm community implementation.
+
+## Scope
+
+### Files changed
+
+| File | Action |
+|---|---|
+| `home/.chezmoidata/packages.toml` | Remove `"asdf"` from common formulae |
+| `home/dot_zshrc.tmpl` | Replace `asdf` with `mise` in OMZ plugins; remove manual `eval "$(mise activate zsh)"` block (plugin handles it); remove `export JAVA_HOME=$(asdf where java 2>/dev/null)`; remove stale pipx comment |
+| `home/dot_p10k.zsh` | Remove `asdf` segment + ~140 lines of `POWERLEVEL9K_ASDF_*` config; add ~30-line `prompt_mise()` custom segment with per-tool colors |
+| `home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl` | Replace `asdf plugin add java` / `asdf install java` with `mise install` / `mise use -g` |
+| `home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl` | Replace `asdf plugin/install/set` with `mise use -g python@3.13` |
+| `CLAUDE.md` | Update script descriptions and zshrc description |
+| `README.md` | Change "via asdf" to "via mise" |
+
+### Not in scope
+
+- macOS `/usr/libexec/java_home` symlinks (IntelliJ handles its own JDK discovery)
+- Migrating any other tools to mise beyond Java and Python
+
+## Script 12: Java install
+
+Before:
+```bash
+asdf plugin add java
+asdf install java adoptopenjdk-21.0.5+11.0.LTS
+asdf install java temurin-24.0.2+12
+```
+
+After:
+```bash
+mise install java@adoptopenjdk-21
+mise install java@temurin-24
+mise use -g java@temurin-24
+```
+
+Both JDKs are installed; temurin-24 is set as the global default. `mise use -g` writes to `~/.config/mise/config.toml`.
+
+## Script 13: Python install
+
+Before:
+```bash
+asdf plugin add python
+asdf install python 3.13.1
+asdf set python 3.13.1
+```
+
+After:
+```bash
+mise use -g python@3.13
+```
+
+`mise use -g` installs and sets the global in one command. mise resolves `3.13` to the latest patch.
+
+## zshrc changes
+
+- **Plugins list**: `asdf` → `mise`. The mise OMZ plugin runs `eval "$(mise activate zsh)"` and sets up tab completions, so the manual activation block is removed.
+- **JAVA_HOME**: The `export JAVA_HOME=$(asdf where java 2>/dev/null)` line is removed. mise's `activate` hook sets JAVA_HOME automatically when it detects a Java installation.
+- **Stale pipx comment**: `# Created by pipx on 2024-06-23` removed (pipx was replaced by uv in a previous commit).
+
+## p10k changes
+
+**Removed**: `asdf` segment from `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS` and the entire `POWERLEVEL9K_ASDF_*` configuration block (~140 lines, 572-710).
+
+**Added**: Custom `prompt_mise()` function (based on dagadbm/dotfiles), appended before the closing brace of the p10k config. The function:
+
+1. Calls `mise ls --local` to list project-level tool versions
+2. Parses tool name + version from the output
+3. Renders each tool as a p10k segment with per-tool foreground colors
+4. Only shows versions for tools that have p10k icons defined
+
+The final line substitutes `asdf` with `mise` in the right prompt elements array:
+```zsh
+typeset -g POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=("${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]/asdf/mise}")
+```
+
+Color scheme matches the previous asdf config (Ruby: 168, Python: 37, Go: 37, Node: 70, Java: 32, etc.).
+
+Display is **local-only**: versions appear only when a project has a `.tool-versions` or `mise.toml` file.
+
+## Alternatives considered
+
+1. **Individual `*_version` segments**: Use p10k's built-in `java_version`, `node_version`, etc. Simpler but no Python version display and less unified.
+2. **Hybrid (keep asdf for prompt)**: Install both tools — confusing, defeats the migration purpose.
+
+## References
+
+- [mise Java docs](https://mise.jdx.dev/lang/java.html)
+- [mise OMZ plugin](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/mise/mise.plugin.zsh)
+- [p10k mise discussion](https://github.com/romkatv/powerlevel10k/issues/2212)
+- [dagadbm p10k.mise.zsh](https://github.com/dagadbm/dotfiles/blob/master/zsh/p10k.mise.zsh)

--- a/docs/plans/2026-02-28-asdf-mise-migration-plan.md
+++ b/docs/plans/2026-02-28-asdf-mise-migration-plan.md
@@ -1,0 +1,418 @@
+# asdf → mise Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove asdf entirely and replace it with mise for all runtime version management (Java, Python, Node.js).
+
+**Architecture:** mise is already activated in `.zshrc` and manages Node.js. This plan migrates Java and Python to mise, removes all asdf traces, and replaces the p10k `asdf` prompt segment with a custom `mise` segment.
+
+**Tech Stack:** chezmoi templates, zsh, Powerlevel10k, mise, Oh-My-Zsh
+
+**Design doc:** `docs/plans/2026-02-28-asdf-mise-migration-design.md`
+
+---
+
+### Task 1: Rewrite Java install script to use mise
+
+**Files:**
+- Modify: `home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl`
+
+**Step 1: Replace asdf commands with mise equivalents**
+
+Replace lines 10-15 (the asdf plugin add + install block) with:
+
+```bash
+# install JDK 21 and JDK 24
+mise install java@adoptopenjdk-21
+mise install java@temurin-24
+
+# set temurin-24 as the global default
+mise use -g java@temurin-24
+```
+
+The full file should become:
+
+```bash
+#!/bin/bash
+{{ if .work_device }}
+set -eufo pipefail
+
+# Add Homebrew to PATH for the current session (required on Apple Silicon)
+if [[ -f /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# install JDK 21 and JDK 24
+mise install java@adoptopenjdk-21
+mise install java@temurin-24
+
+# set temurin-24 as the global default
+mise use -g java@temurin-24
+
+{{ end }}
+```
+
+**Step 2: Verify**
+
+Run: `grep -n asdf home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl`
+Expected: No output (no asdf references remain)
+
+**Step 3: Commit**
+
+```
+git add home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl
+git commit -m "Migrate Java install script from asdf to mise"
+```
+
+---
+
+### Task 2: Rewrite Python install script to use mise
+
+**Files:**
+- Modify: `home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl`
+
+**Step 1: Replace asdf commands with a single mise command**
+
+Replace lines 10-15 (the asdf plugin add + install + set block) with:
+
+```bash
+# install and set Python 3.13 as global default
+mise use -g python@3.13
+```
+
+The full file should become:
+
+```bash
+#!/bin/bash
+{{ if .work_device }}
+set -eufo pipefail
+
+# Add Homebrew to PATH for the current session (required on Apple Silicon)
+if [[ -f /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# install and set Python 3.13 as global default
+mise use -g python@3.13
+
+{{ end }}
+```
+
+**Step 2: Verify**
+
+Run: `grep -n asdf home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl`
+Expected: No output (no asdf references remain)
+
+**Step 3: Commit**
+
+```
+git add home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl
+git commit -m "Migrate Python install script from asdf to mise"
+```
+
+---
+
+### Task 3: Remove asdf from Homebrew packages
+
+**Files:**
+- Modify: `home/.chezmoidata/packages.toml:52`
+
+**Step 1: Delete the asdf formula line**
+
+Remove this exact line (line 52):
+```toml
+            "asdf",                        # Version manager for multiple languages
+```
+
+**Step 2: Verify**
+
+Run: `grep -n asdf home/.chezmoidata/packages.toml`
+Expected: No output
+
+**Step 3: Commit**
+
+```
+git add home/.chezmoidata/packages.toml
+git commit -m "Remove asdf from Homebrew formulae"
+```
+
+---
+
+### Task 4: Update zshrc — replace asdf plugin with mise, clean up
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl`
+
+Four changes in this file, all independent:
+
+**Step 1: Remove manual mise activation block (lines 27-28)**
+
+Delete these two lines:
+```
+### mise — polyglot runtime manager
+eval "$(mise activate zsh)"
+```
+
+The mise OMZ plugin (added in step 2) handles activation and also provides tab completions.
+
+**Step 2: Replace `asdf` with `mise` in plugins list (line 108)**
+
+Change:
+```
+  asdf
+```
+to:
+```
+  mise
+```
+
+**Step 3: Remove JAVA_HOME export (line 214)**
+
+Delete this line:
+```
+export JAVA_HOME=$(asdf where java 2>/dev/null)
+```
+
+mise's `activate` hook sets JAVA_HOME automatically.
+
+**Step 4: Remove stale pipx comment (line 221)**
+
+Delete this line:
+```
+# Created by `pipx` on 2024-06-23 20:44:40
+```
+
+Keep the `export PATH="$PATH:$HOME/.local/bin"` line below it — uv uses that path.
+
+**Step 5: Verify**
+
+Run: `grep -n asdf home/dot_zshrc.tmpl`
+Expected: No output
+
+Run: `grep -n 'mise activate' home/dot_zshrc.tmpl`
+Expected: No output (plugin handles it now)
+
+Run: `grep -n 'mise' home/dot_zshrc.tmpl`
+Expected: One match — the `mise` plugin in the plugins list
+
+**Step 6: Commit**
+
+```
+git add home/dot_zshrc.tmpl
+git commit -m "Replace asdf OMZ plugin with mise, remove manual activation and JAVA_HOME"
+```
+
+---
+
+### Task 5: Update p10k — remove asdf segment and config, add mise segment
+
+**Files:**
+- Modify: `home/dot_p10k.zsh`
+
+Three changes:
+
+**Step 1: Replace `asdf` with `mise` in the right prompt elements (line 53)**
+
+Change:
+```
+    asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
+```
+to:
+```
+    mise                    # mise runtime versions (https://mise.jdx.dev)
+```
+
+**Step 2: Remove the entire POWERLEVEL9K_ASDF_* config block (lines 572-710)**
+
+Delete everything from:
+```
+  ###############[ asdf: asdf version manager (https://github.com/asdf-vm/asdf) ]###############
+```
+through to (and including):
+```
+  # typeset -g POWERLEVEL9K_ASDF_JULIA_SHOW_ON_UPGLOB='*.foo|*.bar'
+```
+
+This is approximately 140 lines. The next section after it starts with:
+```
+  ##########[ nordvpn: nordvpn connection status, linux only (https://nordvpn.com/) ]###########
+```
+
+**Step 3: Add the custom prompt_mise() function and colors**
+
+Insert the following block at line 1649 (after the "User-defined prompt segments" comment block, before the "Transient prompt" section). Specifically, insert after:
+```
+  # typeset -g POWERLEVEL9K_EXAMPLE_VISUAL_IDENTIFIER_EXPANSION='⭐'
+```
+
+and before:
+```
+  # Transient prompt works similarly to the builtin transient_rprompt option.
+```
+
+Insert this block:
+
+```zsh
+  ###############[ mise: mise runtime versions (https://mise.jdx.dev) ]###############
+  function prompt_mise() {
+    local plugins=("${(@f)$(mise ls --local 2>/dev/null | awk '!/\(symlink\)/ && $3!="~/.tool-versions" && $3!="~/.config/mise/config.toml" {print $1, $2}')}")
+    local plugin
+    for plugin in ${(k)plugins}; do
+      local parts=("${(@s/ /)plugin}")
+      local tool=${(U)parts[1]}
+      local version=${parts[2]}
+
+      local icon_var="POWERLEVEL9K_${tool}_ICON"
+      if [[ -n "${(P)icon_var}" ]] || [[ -n "${icons[${tool}_ICON]}" ]]; then
+        p10k segment -r -i "${tool}_ICON" -s $tool -t "$version"
+      fi
+    done
+  }
+
+  typeset -g POWERLEVEL9K_MISE_FOREGROUND=66
+  typeset -g POWERLEVEL9K_MISE_RUBY_FOREGROUND=168
+  typeset -g POWERLEVEL9K_MISE_PYTHON_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_GOLANG_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_NODEJS_FOREGROUND=70
+  typeset -g POWERLEVEL9K_MISE_RUST_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_DOTNET_CORE_FOREGROUND=134
+  typeset -g POWERLEVEL9K_MISE_FLUTTER_FOREGROUND=38
+  typeset -g POWERLEVEL9K_MISE_LUA_FOREGROUND=32
+  typeset -g POWERLEVEL9K_MISE_JAVA_FOREGROUND=32
+  typeset -g POWERLEVEL9K_MISE_PERL_FOREGROUND=67
+  typeset -g POWERLEVEL9K_MISE_ERLANG_FOREGROUND=125
+  typeset -g POWERLEVEL9K_MISE_ELIXIR_FOREGROUND=129
+  typeset -g POWERLEVEL9K_MISE_POSTGRES_FOREGROUND=31
+  typeset -g POWERLEVEL9K_MISE_PHP_FOREGROUND=99
+  typeset -g POWERLEVEL9K_MISE_HASKELL_FOREGROUND=172
+  typeset -g POWERLEVEL9K_MISE_JULIA_FOREGROUND=70
+```
+
+**Step 4: Verify**
+
+Run: `grep -n asdf home/dot_p10k.zsh`
+Expected: No output
+
+Run: `grep -n 'prompt_mise\|MISE' home/dot_p10k.zsh`
+Expected: Multiple matches — the new function and color definitions
+
+**Step 5: Commit**
+
+```
+git add home/dot_p10k.zsh
+git commit -m "Replace p10k asdf segment with custom mise prompt segment"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+**Step 1: Update CLAUDE.md script descriptions**
+
+Line 35 — change:
+```
+* `01_mac_setup` — Dock prefs, NVM dir, macOS updates (work only)
+```
+to:
+```
+* `01_mac_setup` — Dock prefs, macOS updates (work only)
+```
+
+Line 37 — change:
+```
+* `11_install_python` — pipx, poetry
+```
+to:
+```
+* `11_install_python` — uv tool management
+```
+
+Line 38 — change:
+```
+* `12_install_java` — asdf java plugin, JDK 21/24 (work only)
+```
+to:
+```
+* `12_install_java` — mise java, JDK 21/24 (work only)
+```
+
+Line 39 — change:
+```
+* `13_install_python` — asdf python plugin, Python 3.13.1 (work only)
+```
+to:
+```
+* `13_install_python` — mise python, Python 3.13 (work only)
+```
+
+Line 50 — change:
+```
+* `dot_zshrc.tmpl` — main shell config (Oh-My-Zsh, Powerlevel10k, asdf, nvm, pyenv, fzf)
+```
+to:
+```
+* `dot_zshrc.tmpl` — main shell config (Oh-My-Zsh, Powerlevel10k, mise, fzf)
+```
+
+**Step 2: Update README.md**
+
+Line 72 — change:
+```
+- For work devices: enable automatic macOS updates, install Java 21 + 24 and Python 3.13.1 via asdf
+```
+to:
+```
+- For work devices: enable automatic macOS updates, install Java 21 + 24 and Python 3.13 via mise
+```
+
+Line 71 — change:
+```
+- Install pipx
+```
+to:
+```
+- Configure uv tool management
+```
+
+**Step 3: Verify**
+
+Run: `grep -rn asdf CLAUDE.md README.md`
+Expected: No output
+
+**Step 4: Commit**
+
+```
+git add CLAUDE.md README.md
+git commit -m "Update docs: replace asdf/pipx references with mise/uv"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1: Full-codebase asdf audit**
+
+Run: `grep -rn 'asdf\|ASDF' --include='*.tmpl' --include='*.toml' --include='*.zsh' --include='*.md' .`
+
+Expected: Only matches in:
+- `docs/plans/` (design/plan documents — these are historical records, leave them)
+- `migration-kit-backup/` (archive — leave it)
+- `.worktrees/` (stale worktree — leave it)
+
+No matches in `home/`, `CLAUDE.md`, or `README.md`.
+
+**Step 2: Verify commit log**
+
+Run: `git log --oneline -6`
+
+Expected: 6 new commits in order:
+1. Migrate Java install script from asdf to mise
+2. Migrate Python install script from asdf to mise
+3. Remove asdf from Homebrew formulae
+4. Replace asdf OMZ plugin with mise, remove manual activation and JAVA_HOME
+5. Replace p10k asdf segment with custom mise prompt segment
+6. Update docs: replace asdf/pipx references with mise/uv

--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -49,7 +49,6 @@
             "act",                         # Run GitHub Actions locally
             "agg",                         # asciinema GIF generator
             "asciinema",                   # Terminal session recorder
-            "asdf",                        # Version manager for multiple languages
             "bash",                        # Bourne Again SHell
             "bat",                         # cat with syntax highlighting
             "chezmoi",                     # Dotfile manager

--- a/home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_12_install_java.sh.tmpl
@@ -7,11 +7,11 @@ if [[ -f /opt/homebrew/bin/brew ]]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-# add Java plugin
-asdf plugin add java
+# install JDK 21 and JDK 24
+mise install java@adoptopenjdk-21
+mise install java@temurin-24
 
-# install JDK 21
-asdf install java adoptopenjdk-21.0.5+11.0.LTS
-asdf install java temurin-24.0.2+12
+# set temurin-24 as the global default
+mise use -g java@temurin-24
 
 {{ end }}

--- a/home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_13_install_python.tmpl
@@ -7,11 +7,7 @@ if [[ -f /opt/homebrew/bin/brew ]]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-# add Python plugin
-asdf plugin add python
-
-asdf install python 3.13.1
-
-asdf set python 3.13.1
+# install and set Python 3.13 as global default
+mise use -g python@3.13
 
 {{ end }}

--- a/home/dot_p10k.zsh
+++ b/home/dot_p10k.zsh
@@ -50,7 +50,7 @@
     command_execution_time  # duration of the last command
     background_jobs         # presence of background jobs
     direnv                  # direnv status (https://direnv.net/)
-    asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
+    mise                    # mise runtime versions (https://mise.jdx.dev)
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
     anaconda                # conda environment (https://conda.io/)
     goenv                   # go environment (https://github.com/syndbg/goenv)
@@ -568,146 +568,6 @@
   typeset -g POWERLEVEL9K_DIRENV_FOREGROUND=178
   # Custom icon.
   # typeset -g POWERLEVEL9K_DIRENV_VISUAL_IDENTIFIER_EXPANSION='⭐'
-
-  ###############[ asdf: asdf version manager (https://github.com/asdf-vm/asdf) ]###############
-  # Default asdf color. Only used to display tools for which there is no color override (see below).
-  # Tip:  Override this parameter for ${TOOL} with POWERLEVEL9K_ASDF_${TOOL}_FOREGROUND.
-  typeset -g POWERLEVEL9K_ASDF_FOREGROUND=66
-
-  # There are four parameters that can be used to hide asdf tools. Each parameter describes
-  # conditions under which a tool gets hidden. Parameters can hide tools but not unhide them. If at
-  # least one parameter decides to hide a tool, that tool gets hidden. If no parameter decides to
-  # hide a tool, it gets shown.
-  #
-  # Special note on the difference between POWERLEVEL9K_ASDF_SOURCES and
-  # POWERLEVEL9K_ASDF_PROMPT_ALWAYS_SHOW. Consider the effect of the following commands:
-  #
-  #   asdf local  python 3.8.1
-  #   asdf global python 3.8.1
-  #
-  # After running both commands the current python version is 3.8.1 and its source is "local" as
-  # it takes precedence over "global". If POWERLEVEL9K_ASDF_PROMPT_ALWAYS_SHOW is set to false,
-  # it'll hide python version in this case because 3.8.1 is the same as the global version.
-  # POWERLEVEL9K_ASDF_SOURCES will hide python version only if the value of this parameter doesn't
-  # contain "local".
-
-  # Hide tool versions that don't come from one of these sources.
-  #
-  # Available sources:
-  #
-  # - shell   `asdf current` says "set by ASDF_${TOOL}_VERSION environment variable"
-  # - local   `asdf current` says "set by /some/not/home/directory/file"
-  # - global  `asdf current` says "set by /home/username/file"
-  #
-  # Note: If this parameter is set to (shell local global), it won't hide tools.
-  # Tip:  Override this parameter for ${TOOL} with POWERLEVEL9K_ASDF_${TOOL}_SOURCES.
-  typeset -g POWERLEVEL9K_ASDF_SOURCES=(shell local global)
-
-  # If set to false, hide tool versions that are the same as global.
-  #
-  # Note: The name of this parameter doesn't reflect its meaning at all.
-  # Note: If this parameter is set to true, it won't hide tools.
-  # Tip:  Override this parameter for ${TOOL} with POWERLEVEL9K_ASDF_${TOOL}_PROMPT_ALWAYS_SHOW.
-  typeset -g POWERLEVEL9K_ASDF_PROMPT_ALWAYS_SHOW=false
-
-  # If set to false, hide tool versions that are equal to "system".
-  #
-  # Note: If this parameter is set to true, it won't hide tools.
-  # Tip: Override this parameter for ${TOOL} with POWERLEVEL9K_ASDF_${TOOL}_SHOW_SYSTEM.
-  typeset -g POWERLEVEL9K_ASDF_SHOW_SYSTEM=true
-
-  # If set to non-empty value, hide tools unless there is a file matching the specified file pattern
-  # in the current directory, or its parent directory, or its grandparent directory, and so on.
-  #
-  # Note: If this parameter is set to empty value, it won't hide tools.
-  # Note: SHOW_ON_UPGLOB isn't specific to asdf. It works with all prompt segments.
-  # Tip: Override this parameter for ${TOOL} with POWERLEVEL9K_ASDF_${TOOL}_SHOW_ON_UPGLOB.
-  #
-  # Example: Hide nodejs version when there is no package.json and no *.js files in the current
-  # directory, in `..`, in `../..` and so on.
-  #
-  #   typeset -g POWERLEVEL9K_ASDF_NODEJS_SHOW_ON_UPGLOB='*.js|package.json'
-  typeset -g POWERLEVEL9K_ASDF_SHOW_ON_UPGLOB=
-
-  # Ruby version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_RUBY_FOREGROUND=168
-  # typeset -g POWERLEVEL9K_ASDF_RUBY_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_RUBY_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Python version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_PYTHON_FOREGROUND=37
-  # typeset -g POWERLEVEL9K_ASDF_PYTHON_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_PYTHON_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Go version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_GOLANG_FOREGROUND=37
-  # typeset -g POWERLEVEL9K_ASDF_GOLANG_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_GOLANG_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Node.js version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_NODEJS_FOREGROUND=70
-  # typeset -g POWERLEVEL9K_ASDF_NODEJS_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_NODEJS_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Rust version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_RUST_FOREGROUND=37
-  # typeset -g POWERLEVEL9K_ASDF_RUST_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_RUST_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # .NET Core version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_DOTNET_CORE_FOREGROUND=134
-  # typeset -g POWERLEVEL9K_ASDF_DOTNET_CORE_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_DOTNET_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Flutter version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_FLUTTER_FOREGROUND=38
-  # typeset -g POWERLEVEL9K_ASDF_FLUTTER_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_FLUTTER_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Lua version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_LUA_FOREGROUND=32
-  # typeset -g POWERLEVEL9K_ASDF_LUA_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_LUA_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Java version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_JAVA_FOREGROUND=32
-  # typeset -g POWERLEVEL9K_ASDF_JAVA_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_JAVA_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Perl version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_PERL_FOREGROUND=67
-  # typeset -g POWERLEVEL9K_ASDF_PERL_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_PERL_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Erlang version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_ERLANG_FOREGROUND=125
-  # typeset -g POWERLEVEL9K_ASDF_ERLANG_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_ERLANG_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Elixir version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_ELIXIR_FOREGROUND=129
-  # typeset -g POWERLEVEL9K_ASDF_ELIXIR_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_ELIXIR_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Postgres version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_POSTGRES_FOREGROUND=31
-  # typeset -g POWERLEVEL9K_ASDF_POSTGRES_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_POSTGRES_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # PHP version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_PHP_FOREGROUND=99
-  # typeset -g POWERLEVEL9K_ASDF_PHP_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_PHP_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Haskell version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_HASKELL_FOREGROUND=172
-  # typeset -g POWERLEVEL9K_ASDF_HASKELL_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_HASKELL_SHOW_ON_UPGLOB='*.foo|*.bar'
-
-  # Julia version from asdf.
-  typeset -g POWERLEVEL9K_ASDF_JULIA_FOREGROUND=70
-  # typeset -g POWERLEVEL9K_ASDF_JULIA_VISUAL_IDENTIFIER_EXPANSION='⭐'
-  # typeset -g POWERLEVEL9K_ASDF_JULIA_SHOW_ON_UPGLOB='*.foo|*.bar'
 
   ##########[ nordvpn: nordvpn connection status, linux only (https://nordvpn.com/) ]###########
   # NordVPN connection indicator color.
@@ -1647,6 +1507,40 @@
   # User-defined prompt segments can be customized the same way as built-in segments.
   # typeset -g POWERLEVEL9K_EXAMPLE_FOREGROUND=208
   # typeset -g POWERLEVEL9K_EXAMPLE_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  ###############[ mise: mise runtime versions (https://mise.jdx.dev) ]###############
+  function prompt_mise() {
+    local plugins=("${(@f)$(mise ls --local 2>/dev/null | awk '!/\(symlink\)/ && $3!="~/.tool-versions" && $3!="~/.config/mise/config.toml" {print $1, $2}')}")
+    local plugin
+    for plugin in ${(k)plugins}; do
+      local parts=("${(@s/ /)plugin}")
+      local tool=${(U)parts[1]}
+      local version=${parts[2]}
+
+      local icon_var="POWERLEVEL9K_${tool}_ICON"
+      if [[ -n "${(P)icon_var}" ]] || [[ -n "${icons[${tool}_ICON]}" ]]; then
+        p10k segment -r -i "${tool}_ICON" -s $tool -t "$version"
+      fi
+    done
+  }
+
+  typeset -g POWERLEVEL9K_MISE_FOREGROUND=66
+  typeset -g POWERLEVEL9K_MISE_RUBY_FOREGROUND=168
+  typeset -g POWERLEVEL9K_MISE_PYTHON_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_GOLANG_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_NODEJS_FOREGROUND=70
+  typeset -g POWERLEVEL9K_MISE_RUST_FOREGROUND=37
+  typeset -g POWERLEVEL9K_MISE_DOTNET_CORE_FOREGROUND=134
+  typeset -g POWERLEVEL9K_MISE_FLUTTER_FOREGROUND=38
+  typeset -g POWERLEVEL9K_MISE_LUA_FOREGROUND=32
+  typeset -g POWERLEVEL9K_MISE_JAVA_FOREGROUND=32
+  typeset -g POWERLEVEL9K_MISE_PERL_FOREGROUND=67
+  typeset -g POWERLEVEL9K_MISE_ERLANG_FOREGROUND=125
+  typeset -g POWERLEVEL9K_MISE_ELIXIR_FOREGROUND=129
+  typeset -g POWERLEVEL9K_MISE_POSTGRES_FOREGROUND=31
+  typeset -g POWERLEVEL9K_MISE_PHP_FOREGROUND=99
+  typeset -g POWERLEVEL9K_MISE_HASKELL_FOREGROUND=172
+  typeset -g POWERLEVEL9K_MISE_JULIA_FOREGROUND=70
 
   # Transient prompt works similarly to the builtin transient_rprompt option. It trims down prompt
   # when accepting a command line. Supported values:

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -24,9 +24,6 @@ function . {
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-### mise — polyglot runtime manager
-eval "$(mise activate zsh)"
-
 # Python SSL Certs
 # export SSL_CERT_FILE=~/all_mac_certs.pem
 # export REQUESTS_CA_BUNDLE=~/all_mac_certs.pem
@@ -105,7 +102,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
-  asdf
+  mise
   aws
   # composer
   gcloud
@@ -211,14 +208,11 @@ bindkey -M emacs '^N' history-substring-search-down
 
 export PATH="$PATH":"$HOME/.pub-cache/bin"
 
-export JAVA_HOME=$(asdf where java 2>/dev/null)
-
 # Initialize rbenv if it exists
 if command -v rbenv >/dev/null 2>&1; then
   eval "$(rbenv init - zsh)"
 fi
 
-# Created by `pipx` on 2024-06-23 20:44:40
 export PATH="$PATH:$HOME/.local/bin"
 
 # chezmoi customizations 2


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary

- Migrate Java and Python install scripts from `asdf` to `mise` (`mise use -g` replaces 3-step `asdf plugin add` / `asdf install` / `asdf set`)
- Remove `asdf` from Homebrew formulae — `mise` (already installed) is the sole runtime manager
- Replace `asdf` OMZ plugin with `mise` plugin (handles activation + tab completions)
- Remove manual `eval "$(mise activate zsh)"` and `export JAVA_HOME=$(asdf where java)` — the mise plugin and hook-env handle both
- Replace p10k `asdf` prompt segment (~140 lines of config) with a custom `prompt_mise()` function based on [dagadbm/dotfiles](https://github.com/dagadbm/dotfiles/blob/master/zsh/p10k.mise.zsh) — shows local project tool versions with per-language colors
- Update CLAUDE.md and README.md to reflect mise/uv instead of asdf/pipx

## Test plan

- [ ] Run `chezmoi apply` and verify no template errors
- [ ] Open a new terminal — confirm prompt loads without errors
- [ ] Verify `mise current` shows Java and Python versions
- [ ] Verify `JAVA_HOME` is set correctly (`echo $JAVA_HOME`)
- [ ] `cd` into a project with `.tool-versions` or `mise.toml` and confirm the mise p10k segment appears
- [ ] Verify `mise` tab completions work (type `mise ` + Tab)
- [ ] Run `brew uninstall asdf` to remove the now-unmanaged formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)