### PR TITLE
Auto-position Dock based on monitor count

### DIFF
--- a/home/.chezmoiscripts/run_before_00_dock_position.sh
+++ b/home/.chezmoiscripts/run_before_00_dock_position.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eufo pipefail
+
+# Position dock based on number of active monitors
+# - left when only one display is connected (maximize horizontal space)
+# - bottom when multiple displays are connected (centered across screens)
+display_count=$(system_profiler SPDisplaysDataType | grep -c "Online: Yes")
+if [ "$display_count" -gt 1 ]; then
+  defaults write com.apple.dock orientation -string bottom
+else
+  defaults write com.apple.dock orientation -string left
+fi

--- a/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
@@ -5,9 +5,6 @@ set -eufo pipefail
 # Update dock icon size
 defaults write com.apple.dock tilesize -int 48
 
-# move dock to the left
-defaults write com.apple.dock orientation -string left
-
 # This script changes the macOS system preference for the scroll direction.
 # It sets the "Natural" scrolling direction to false, which means that the scroll direction will be reversed.
 # This is equivalent to unchecking the "Scroll direction: Natural" option in System Preferences > Trackpad.


### PR DESCRIPTION
> [!WARNING]
> * This PR was reverted and reimplemented correctly in #38 

> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Split dock positioning out of `run_onchange_before_01_mac_setup.sh.tmpl` into a new `run_before_00_dock_position.sh` script
- New script runs on **every** `chezmoi apply` (not just on content change), so it picks up monitor changes without needing `--force`
- Detects active display count via `system_profiler SPDisplaysDataType | grep -c "Online: Yes"`
- Sets Dock to **left** for single monitor, **bottom** for 2+ monitors
- Numbered `00` to run before the existing `01_mac_setup` script (which does `killall Dock`)

## Test plan
- [ ] Run `system_profiler SPDisplaysDataType | grep -c "Online: Yes"` to verify display count matches expectations
- [ ] Run `chezmoi apply` with multiple monitors — verify Dock moves to bottom
- [ ] Disconnect external monitors, run `chezmoi apply` again — verify Dock moves to left
- [ ] Verify `chezmoi apply` with no source changes still re-runs the dock script (since it's `run_before_`, not `run_onchange_`)

🤖 Generated with [Claude Code](https://claude.ai/code)