### PR TITLE
Auto-position Dock based on monitor count

### DIFF
--- a/home/.chezmoiscripts/run_after_99_restart_ui.sh
+++ b/home/.chezmoiscripts/run_after_99_restart_ui.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eufo pipefail
+
+# Restart UI processes to apply any changes from earlier scripts
+killall Dock
+killall Finder
+killall SystemUIServer

--- a/home/.chezmoiscripts/run_before_00_dock_position.sh
+++ b/home/.chezmoiscripts/run_before_00_dock_position.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eufo pipefail
+
+# Position dock based on number of active monitors
+# - left when only one display is connected (maximize horizontal space)
+# - bottom when multiple displays are connected (centered across screens)
+display_count=$(system_profiler SPDisplaysDataType | grep -c "Online: Yes")
+if [ "$display_count" -gt 1 ]; then
+  defaults write com.apple.dock orientation -string bottom
+else
+  defaults write com.apple.dock orientation -string left
+fi

--- a/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
@@ -5,9 +5,6 @@ set -eufo pipefail
 # Update dock icon size
 defaults write com.apple.dock tilesize -int 48
 
-# move dock to the left
-defaults write com.apple.dock orientation -string left
-
 # This script changes the macOS system preference for the scroll direction.
 # It sets the "Natural" scrolling direction to false, which means that the scroll direction will be reversed.
 # This is equivalent to unchecking the "Scroll direction: Natural" option in System Preferences > Trackpad.
@@ -28,12 +25,3 @@ sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool tru
 sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool true
 
 {{ end }}
-
-# Restart the Dock to apply changes
-killall Dock
-
-# Restart the Finder to apply changes
-killall Finder
-
-# Restart the SystemUIServer to apply changes
-killall SystemUIServer


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Extract dock positioning into `run_before_00_dock_position.sh` — detects active displays via `system_profiler SPDisplaysDataType` and sets orientation to **left** (1 monitor) or **bottom** (2+)
- Extract UI process restarts into `run_after_99_restart_ui.sh` — ensures `killall Dock/Finder/SystemUIServer` runs after all settings are written
- Both new scripts use `run_before_`/`run_after_` (not `run_onchange_`), so they execute on **every** `chezmoi apply`, picking up monitor changes without needing `--force`
- Remove hardcoded dock orientation and killall commands from `run_onchange_before_01_mac_setup.sh.tmpl`

## Script execution order
1. `run_before_00_dock_position.sh` — detect monitors, set dock orientation *(every apply)*
2. `run_onchange_before_01_mac_setup.sh.tmpl` — tile size, scroll direction, macOS updates *(on content change)*
3. *(chezmoi applies files/templates)*
4. `run_after_99_restart_ui.sh` — restart Dock, Finder, SystemUIServer *(every apply)*

## Test plan
- [ ] Run `system_profiler SPDisplaysDataType | grep -c "Online: Yes"` to verify display count
- [ ] `chezmoi apply` with multiple monitors — dock moves to bottom
- [ ] Disconnect external monitors, `chezmoi apply` — dock moves to left
- [ ] Confirm `chezmoi apply` with no source changes still re-runs `run_before_` and `run_after_` scripts

🤖 Generated with [Claude Code](https://claude.ai/code)