### PR TITLE
Add worktree-aware chezmoi aliases (cmaw, cmdw)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,4 @@ Current scripts:
 * `run_onchange` scripts re-run when template *output* changes, not just source edits
 * Use `run_before_`/`run_after_` (not `run_onchange_`) for scripts that depend on runtime environment (e.g., monitor count)
 * chezmoi source is available locally at `/Users/omair/libs/chezmoi` for reference
+* `chezmoi apply/diff` always uses the configured source dir, not `$PWD` — in git worktrees, use `--source=<worktree>/home` or the `cmaw`/`cmdw` aliases

--- a/home/dot_zsh_aliases.tmpl
+++ b/home/dot_zsh_aliases.tmpl
@@ -212,6 +212,25 @@ alias cmdoc="chezmoi doctor"
 # Homebrew cleanup (compare installed packages against chezmoi Brewfile)
 alias cmclean="brew bundle cleanup --file=~/.Brewfile"
 alias cmcleanf="brew bundle cleanup --force --file=~/.Brewfile"
+# Worktree-aware chezmoi commands (use from git worktrees)
+function cmaw() {
+  local src
+  src="$(git rev-parse --show-toplevel 2>/dev/null)/home"
+  if [[ ! -d "$src" ]]; then
+    echo "Not in a chezmoi worktree (no home/ directory found)"
+    return 1
+  fi
+  chezmoi apply --source="$src" "$@"
+}
+function cmdw() {
+  local src
+  src="$(git rev-parse --show-toplevel 2>/dev/null)/home"
+  if [[ ! -d "$src" ]]; then
+    echo "Not in a chezmoi worktree (no home/ directory found)"
+    return 1
+  fi
+  chezmoi diff --source="$src" "$@"
+}
 
 # unset GITHUB_TOKEN from gh's process environment and run gh command.
 # see https://stackoverflow.com/a/41749660 & https://github.com/cli/cli/issues/3799 for more.


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Add `cmaw` function: runs `chezmoi apply --source=<worktree>/home` to apply chezmoi from a git worktree instead of the main source dir
- Add `cmdw` function: runs `chezmoi diff --source=<worktree>/home` to preview worktree changes before applying
- Both auto-detect the worktree root via `git rev-parse --show-toplevel` and pass through extra flags
- Document the worktree gotcha in CLAUDE.md Gotchas section

## Test plan
- [ ] Run `chezmoi apply` to install the new aliases
- [ ] Source `~/.zshrc` (or use `.` shortcut)
- [ ] From the main chezmoi repo: verify `cmdw` shows the same output as `chezmoi diff`
- [ ] From a git worktree: verify `cmdw` diffs against the worktree source, not `~/.local/share/chezmoi`
- [ ] From a non-chezmoi directory: verify `cmdw` and `cmaw` print an error message and return 1
- [ ] Verify extra flags pass through (e.g., `cmaw --dry-run -v`)

🤖 Generated with [Claude Code](https://claude.ai/code)