### PR TITLE
Replace alias-tips plugin with built-in alias-finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # 1Password CLI local plugin config (machine-specific, contains vault/item IDs)
 .op/
 
+# Worktrees
+.worktrees/
+
 # Temp files
 chezmoi_diff.txt
 demo.gif

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -96,6 +96,9 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
+# alias-finder: auto-suggest aliases when typing full commands
+ZSH_ALIAS_FINDER_AUTOMATIC=true
+
 # Which plugins would you like to load?
 # Standard plugins can be found in $ZSH/plugins/
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
@@ -108,7 +111,7 @@ plugins=(
   gcloud
   git 
   forgit
-  alias-tips
+  alias-finder
   zsh-autosuggestions
   zsh-completions
   zsh-eza

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -111,6 +111,7 @@ plugins=(
   gcloud
   git 
   forgit
+  aliases
   alias-finder
   zsh-autosuggestions
   zsh-completions

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,6 @@ install_plugin "Powerlevel10k" "https://github.com/romkatv/powerlevel10k.git" "t
 
 # Install custom plugins
 install_plugin "zsh-autosuggestions" "https://github.com/zsh-users/zsh-autosuggestions" "plugins/zsh-autosuggestions"
-install_plugin "alias-tips" "https://github.com/djui/alias-tips.git" "plugins/alias-tips"
 install_plugin "zsh-history-substring-search" "https://github.com/zsh-users/zsh-history-substring-search" "plugins/zsh-history-substring-search"
 install_plugin "forgit" "https://github.com/wfxr/forgit.git" "plugins/forgit"
 install_plugin "zsh-completions" "https://github.com/zsh-users/zsh-completions" "plugins/zsh-completions"


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Replace custom `alias-tips` plugin (djui/alias-tips) with OMZ built-in `alias-finder`
- Add `ZSH_ALIAS_FINDER_AUTOMATIC=true` to preserve auto-suggest behavior
- Remove `alias-tips` clone from `install.sh` (alias-finder is built-in, no install needed)

## Context
Per the plugin survey at `docs/notes/2026-02-28-omz-plugin-survey.md`, `alias-finder` provides equivalent functionality without requiring an external clone.

## Test plan
- [ ] Run `chezmoi diff` to confirm only expected changes
- [ ] Run `chezmoi apply` to deploy
- [ ] Open new terminal, type a full command with an alias (e.g. `git status`) — alias-finder should suggest `gst`
- [ ] Optionally remove old plugin dir: `rm -rf ~/.oh-my-zsh/custom/plugins/alias-tips/`

🤖 Generated with [Claude Code](https://claude.ai/code)