### PR TITLE
perf(zsh): optimize shell startup and fix 1Password prompts

### DIFF
--- a/docs/plans/2026-02-28-zsh-startup-optimization-design.md
+++ b/docs/plans/2026-02-28-zsh-startup-optimization-design.md
@@ -1,0 +1,143 @@
+# ZSH Startup Optimization Design
+
+**Date:** 2026-02-28
+**Goal:** Reduce shell startup time to under 500ms while keeping Oh My Zsh, Powerlevel10k, and all essential plugin functionality.
+
+**Approach:** Optimize within the current OMZ + p10k stack. No framework or prompt replacement. Fix redundancies, remove dead weight, defer expensive initialization.
+
+---
+
+## Current State
+
+- **Framework:** Oh My Zsh with ~30 plugins (plus k8s/docker on work devices)
+- **Prompt:** Powerlevel10k (lean, 2-line, nerdfont-complete, instant prompt enabled)
+- **Known bottlenecks:** duplicate `compinit`, synchronous `rbenv init`, per-shell JWT completion generation, redundant autojump alongside zoxide
+
+## Changes
+
+### 1. Remove duplicate `compinit` call
+
+**File:** `dot_zshrc.tmpl`, line 183
+
+`autoload -U compinit && compinit` runs before `source $ZSH/oh-my-zsh.sh`, which calls `compinit` internally. Each `compinit` call scans every file in `$fpath` — with 30+ plugins, this costs 50-100ms. The duplicate wastes that time for zero benefit.
+
+**Action:** Delete line 183.
+**Estimated savings:** 50-100ms
+
+### 2. Remove duplicate aliases and functions from `.zshrc`
+
+**File:** `dot_zshrc.tmpl`, lines 8-10 and 16-23
+
+The `ifactive` alias, `ssh-hosts` alias, and `.` function are defined in both `.zshrc` and `.zsh_aliases`. Since `.zsh_aliases` is sourced on line 11, the `.zshrc` copies are redundant.
+
+**Action:** Remove lines 8-10 and 16-23 from `dot_zshrc.tmpl`.
+**Estimated savings:** Negligible (cleanliness, not speed)
+
+### 3. Remove autojump
+
+**File:** `dot_zshrc.tmpl`, line 221
+
+The `zoxide` OMZ plugin (line 167) provides the same directory-jumping functionality. Autojump is slower (Python-based vs Rust-based zoxide) and redundant.
+
+**Action:** Remove line 221. Consider `brew uninstall autojump` as follow-up.
+**Estimated savings:** 20-30ms
+
+### 4. Remove `rbenv init` block
+
+**File:** `dot_zshrc.tmpl`, lines 236-238
+
+`eval "$(rbenv init - zsh)"` forks a subprocess on every shell start. Since `mise` now manages Ruby versions, rbenv is unnecessary.
+
+**Action:** Remove lines 236-238. Also remove the `rbenv` segment from `dot_p10k.zsh` right-prompt elements.
+**Estimated savings:** 100-200ms
+
+### 5. Cache JWT completions
+
+**File:** `dot_zshrc.tmpl`, lines 223-225
+
+`source <(jwt completion zsh)` regenerates identical completion output on every shell start. Cache the output to a file instead.
+
+**Action:** Replace the subprocess call with a cached file:
+- Create `~/.zsh_completions/` directory
+- Generate `_jwt` completion file via a chezmoi run_onchange script (or manual one-time command)
+- Add `fpath=(~/.zsh_completions $fpath)` before OMZ sourcing
+- Remove lines 223-225
+
+**Estimated savings:** 30-50ms
+
+### 6. Remove unused plugins
+
+**File:** `dot_zshrc.tmpl`, plugins array
+
+- Remove `sfdx` — Salesforce CLI, not in use
+- Comment out `aws` — not using AWS completions currently; easy to re-enable
+
+**Estimated savings:** ~10-20ms
+
+### 7. Add `evalcache` for expensive plugin init
+
+**New dependency:** [`evalcache`](https://github.com/mroth/evalcache) (install as OMZ custom plugin)
+
+Three OMZ plugins run `eval "$(tool init)"` on every shell start:
+- `direnv` (~30-50ms)
+- `mise` (~30-50ms)
+- `zoxide` (~20-30ms)
+
+`evalcache` caches eval output to `~/.zsh-evalcache/` and sources the cached file on subsequent starts (~1ms each). The cache auto-invalidates when the tool binary changes.
+
+**Action:**
+- Install evalcache to `$ZSH_CUSTOM/plugins/evalcache`
+- Disable the OMZ `direnv`, `mise`, and `zoxide` plugins
+- Add manual init lines using `_evalcache`:
+  ```zsh
+  _evalcache mise activate zsh
+  _evalcache direnv hook zsh
+  _evalcache zoxide init zsh
+  ```
+- Add `evalcache` to the plugins array
+
+**Estimated savings:** 80-130ms
+**Trade-off:** Must run `_evalcache_clear` after upgrading these tools (or it auto-detects binary changes)
+
+---
+
+## Estimated Total Savings
+
+| Change | Low estimate | High estimate |
+|--------|-------------|--------------|
+| Remove duplicate `compinit` | 50ms | 100ms |
+| Remove autojump | 20ms | 30ms |
+| Remove `rbenv init` | 100ms | 200ms |
+| Cache JWT completions | 30ms | 50ms |
+| Remove unused plugins | 10ms | 20ms |
+| Add evalcache (direnv, mise, zoxide) | 80ms | 130ms |
+| **Total** | **290ms** | **530ms** |
+
+With the low estimate alone, a shell starting at ~1s drops to ~700ms. With the high estimate, a ~1.5s shell drops to ~970ms. Combined, these changes should bring startup well under the 500ms target.
+
+## Verification
+
+Measure before and after with:
+```zsh
+# From an existing shell, time a fresh interactive shell:
+time zsh -i -c exit
+
+# For detailed profiling:
+# Add to top of .zshrc: zmodload zsh/zprof
+# Add to bottom of .zshrc: zprof
+```
+
+## What This Design Does NOT Change
+
+- Oh My Zsh remains the framework
+- Powerlevel10k remains the prompt (with instant prompt)
+- All essential plugins remain loaded
+- No visual changes to the prompt
+- `alias-finder` automatic mode stays enabled (per-command cost, not startup)
+- `zsh-syntax-highlighting` sourced from Homebrew after OMZ (correct ordering preserved)
+
+## Future Considerations (Out of Scope)
+
+- **Starship migration:** If p10k breaks on a future ZSH version, Starship is the recommended replacement. This design is compatible with that future migration.
+- **Framework-free setup:** If further speed is needed, replacing OMZ with Antidote or Sheldon + standalone plugins is the next step. Not warranted for the <500ms target.
+- **Per-command latency:** `alias-finder` automatic mode adds ~20-50ms per command. Acceptable for the learning benefit but worth revisiting if command responsiveness feels sluggish.

--- a/docs/plans/2026-02-28-zsh-startup-optimization-plan.md
+++ b/docs/plans/2026-02-28-zsh-startup-optimization-plan.md
@@ -1,0 +1,437 @@
+# ZSH Startup Optimization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce ZSH startup time to under 500ms by removing redundancies, dead weight, and deferring expensive initialization — without changing the OMZ framework or Powerlevel10k prompt.
+
+**Architecture:** Edit the chezmoi-managed `dot_zshrc.tmpl` and `dot_p10k.zsh` to remove duplicate work, drop unused tools, cache completions, and add evalcache for expensive `eval "$(tool init)"` calls. All changes are to the chezmoi source directory; the user runs `chezmoi apply` (alias `cma`) to deploy.
+
+**Tech Stack:** ZSH, Oh My Zsh, chezmoi templates, evalcache plugin
+
+**Design doc:** `docs/plans/2026-02-28-zsh-startup-optimization-design.md`
+
+---
+
+### Task 0: Measure baseline startup time
+
+**Files:** None (read-only measurement)
+
+**Step 1: Record baseline timing**
+
+Run from an existing shell (not inside the shell being measured):
+
+```bash
+# Run 5 times and note the average
+for i in {1..5}; do time zsh -i -c exit; done
+```
+
+Record the `real` time from each run. This is the "before" number.
+
+**Step 2: Commit nothing** — this is observation only.
+
+---
+
+### Task 1: Remove duplicate `compinit` call
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl:183`
+
+**Step 1: Delete the duplicate compinit line**
+
+Remove this line (currently line 183):
+```
+autoload -U compinit && compinit
+```
+
+OMZ calls `compinit` internally when it sources `oh-my-zsh.sh` on line 187. The duplicate scans every file in `$fpath` a second time for no benefit.
+
+**Step 2: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: The diff shows only the removal of the `compinit` line.
+
+**Step 3: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl
+git commit -m "perf(zsh): remove duplicate compinit call
+
+OMZ already calls compinit internally. The duplicate at line 183
+ran before source oh-my-zsh.sh, scanning \$fpath twice (~50-100ms
+wasted)."
+```
+
+---
+
+### Task 2: Remove duplicate aliases and functions from `.zshrc`
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl:8-23`
+
+The `ifactive` alias (line 8-9), `ssh-hosts` alias (line 10), and the `.` function (lines 16-23) are already defined in `home/dot_zsh_aliases.tmpl` (lines 1-14). Since `.zsh_aliases` is sourced on line 11, the `.zshrc` copies are redundant.
+
+**Step 1: Remove the duplicate alias lines**
+
+Remove lines 8-10 (the two aliases before `source ~/.zsh_aliases`):
+```
+### Alias to list active network interfaces
+alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
+alias ssh-hosts="grep -hE 'Host (.+)' ~/.ssh/config | sed 's/Host //'"
+```
+
+The file should go directly from the p10k instant prompt block to `source ~/.zsh_aliases`.
+
+**Step 2: Remove the duplicate `.` function**
+
+Remove lines 16-23 (the `.` function):
+```
+### Typing '.' will source ~/.zshrc
+function . {
+    if [[ $# -eq 0 ]]; then
+        builtin . ~/.zshrc
+    else
+        builtin . "$@"
+    fi
+}
+```
+
+This same function exists in `home/dot_zsh_aliases.tmpl` at lines 7-14.
+
+**Step 3: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: Only the duplicate lines are removed. `source ~/.zsh_aliases` remains.
+
+**Step 4: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl
+git commit -m "perf(zsh): remove duplicate aliases and dot function from .zshrc
+
+These are already defined in .zsh_aliases, which is sourced on the
+next line."
+```
+
+---
+
+### Task 3: Remove autojump (redundant with zoxide)
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl:221`
+
+**Step 1: Remove the autojump source line**
+
+Remove these two lines:
+```
+# Enable autojump
+[ -f /opt/homebrew/etc/profile.d/autojump.sh ] && . /opt/homebrew/etc/profile.d/autojump.sh
+```
+
+The `zoxide` OMZ plugin (in the plugins array at line 167) provides the same `z` command for directory jumping, is written in Rust (faster), and is already active.
+
+**Step 2: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: Only the autojump lines are removed.
+
+**Step 3: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl
+git commit -m "perf(zsh): remove autojump, redundant with zoxide
+
+Zoxide (already loaded as OMZ plugin) provides the same z command
+for directory jumping. Autojump is Python-based and slower."
+```
+
+**Step 4: Note for user** — After applying, optionally run `brew uninstall autojump` to clean up the Homebrew package.
+
+---
+
+### Task 4: Remove rbenv init and p10k rbenv segment
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl:235-238`
+- Modify: `home/dot_p10k.zsh:65`
+
+**Step 1: Remove the rbenv init block from .zshrc**
+
+Remove these lines:
+```
+# Initialize rbenv if it exists
+if command -v rbenv >/dev/null 2>&1; then
+  eval "$(rbenv init - zsh)"
+fi
+```
+
+Mise now manages Ruby versions, making rbenv unnecessary.
+
+**Step 2: Comment out rbenv from p10k right-prompt elements**
+
+In `home/dot_p10k.zsh`, change line 65 from:
+```
+    rbenv                   # ruby version from rbenv (https://github.com/rbenv/rbenv)
+```
+to:
+```
+    # rbenv                   # ruby version from rbenv (https://github.com/rbenv/rbenv)
+```
+
+The `mise` segment on line 53 already shows runtime versions managed by mise.
+
+**Step 3: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc && chezmoi diff ~/.p10k.zsh`
+
+Expected: The rbenv block is removed from .zshrc; the rbenv segment is commented out in .p10k.zsh.
+
+**Step 4: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl home/dot_p10k.zsh
+git commit -m "perf(zsh): remove rbenv init and p10k segment
+
+Mise manages Ruby versions now. The rbenv eval subprocess added
+~100-200ms to every shell start."
+```
+
+---
+
+### Task 5: Cache JWT completions to file
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl:223-225` (remove subprocess call)
+- Modify: `home/dot_zshrc.tmpl` (add fpath entry before OMZ source)
+- Create: `home/.chezmoiscripts/run_onchange_before_14_cache-jwt-completions.sh.tmpl`
+
+**Step 1: Create the completion cache script**
+
+Create `home/.chezmoiscripts/run_onchange_before_14_cache-jwt-completions.sh.tmpl`:
+
+```bash
+#!/bin/bash
+# Cache JWT CLI completions for ZSH so we don't spawn a subprocess on every shell start.
+# Regenerates when jwt binary changes (chezmoi detects via hash comment below).
+# hash: {{ if lookPath "jwt" }}{{ output "jwt" "--version" | trim }}{{ else }}not-installed{{ end }}
+
+set -euo pipefail
+
+COMP_DIR="$HOME/.zsh_completions"
+mkdir -p "$COMP_DIR"
+
+if command -v jwt >/dev/null 2>&1; then
+  echo "Caching JWT ZSH completions to $COMP_DIR/_jwt..."
+  jwt completion zsh > "$COMP_DIR/_jwt"
+else
+  echo "jwt not found, skipping completion cache"
+fi
+```
+
+This is a `run_onchange` script — chezmoi re-runs it only when the hash comment (jwt version) changes.
+
+**Step 2: Add fpath entry before OMZ source**
+
+In `home/dot_zshrc.tmpl`, add this line before the `export ZSH=` line (around line 35):
+
+```bash
+# Cached CLI completions (jwt, etc.)
+fpath=(~/.zsh_completions $fpath)
+```
+
+**Step 3: Remove the subprocess call**
+
+Remove these lines from `home/dot_zshrc.tmpl`:
+```
+if hash jwt > /dev/null; then
+  source <(jwt completion zsh)
+fi
+```
+
+**Step 4: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: The jwt subprocess block is gone; the fpath line is added.
+
+**Step 5: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl home/.chezmoiscripts/run_onchange_before_14_cache-jwt-completions.sh.tmpl
+git commit -m "perf(zsh): cache JWT completions to file instead of subprocess
+
+Replace source <(jwt completion zsh) with a cached file at
+~/.zsh_completions/_jwt. A chezmoi run_onchange script regenerates
+it when the jwt binary version changes."
+```
+
+---
+
+### Task 6: Remove unused plugins (sfdx, aws)
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl` (plugins array)
+
+**Step 1: Remove sfdx and comment out aws**
+
+In the plugins array, remove the `sfdx` line entirely:
+```
+  sfdx
+```
+
+Comment out the `aws` line:
+```
+  # aws  # commented out — re-enable when using AWS completions
+```
+
+**Step 2: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: `sfdx` removed, `aws` commented out.
+
+**Step 3: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl
+git commit -m "perf(zsh): remove sfdx plugin, comment out aws
+
+sfdx (Salesforce CLI) is unused. aws completions are not needed
+currently — easy to re-enable later."
+```
+
+---
+
+### Task 7: Install evalcache and convert mise + zoxide init
+
+**Files:**
+- Modify: `home/dot_zshrc.tmpl` (plugins array + add evalcache init lines)
+
+**Important:** The direnv plugin MUST remain as an OMZ plugin. Unlike mise and zoxide which run a one-time init, direnv installs `precmd`/`chpwd` hooks that re-evaluate on every prompt and directory change. Caching that would break `.envrc` loading.
+
+**Step 1: Install evalcache as OMZ custom plugin**
+
+```bash
+git clone https://github.com/mroth/evalcache.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/evalcache
+```
+
+**Step 2: Update the plugins array**
+
+In `home/dot_zshrc.tmpl`, make these changes to the plugins array:
+
+Add `evalcache` to the top of the plugins list (it must load before we call `_evalcache`):
+```
+plugins=(
+  # Eval caching (must load first)
+  evalcache
+
+  # Package managers & tooling
+  # mise  # replaced by _evalcache below
+  brew
+  chezmoi
+  uv
+```
+
+Remove `mise` and `zoxide` from the plugins array (comment them out with the reason).
+
+Keep `direnv` in the plugins array — it uses hooks, not a one-time eval.
+
+The navigation section becomes:
+```
+  # Navigation & environment
+  # zoxide  # replaced by _evalcache below
+  # auto-load .envrc (direnv) and .env (dotenv) per directory
+  direnv
+  dotenv
+```
+
+**Step 3: Add evalcache init lines after OMZ source**
+
+After `source $ZSH/oh-my-zsh.sh` (and before the p10k source line), add:
+
+```bash
+# Cached eval for expensive tool init (see evalcache plugin)
+# These replace the OMZ mise and zoxide plugins with cached versions.
+# Run _evalcache_clear after upgrading these tools.
+_evalcache mise activate zsh
+_evalcache zoxide init zsh
+```
+
+**Step 4: Verify with chezmoi diff**
+
+Run: `chezmoi diff ~/.zshrc`
+
+Expected: evalcache added to plugins, mise/zoxide removed from plugins, `_evalcache` lines added after OMZ source.
+
+**Step 5: Commit**
+
+```bash
+git add home/dot_zshrc.tmpl
+git commit -m "perf(zsh): add evalcache for mise and zoxide init
+
+Replace OMZ mise and zoxide plugins with evalcache'd manual init.
+Caches eval output to ~/.zsh-evalcache/ — subsequent shells source
+the file (~1ms) instead of forking subprocesses (~30-50ms each).
+
+direnv stays as OMZ plugin because it installs precmd/chpwd hooks
+that must re-evaluate on every prompt, not just once at init."
+```
+
+---
+
+### Task 8: Measure results and verify functionality
+
+**Files:** None (read-only verification)
+
+**Step 1: Apply chezmoi changes**
+
+```bash
+chezmoi apply -v
+```
+
+**Step 2: Open a new shell and measure startup time**
+
+```bash
+for i in {1..5}; do time zsh -i -c exit; done
+```
+
+Compare against baseline from Task 0. Target: under 500ms.
+
+**Step 3: Verify key functionality still works**
+
+Test each category:
+- `gst` — git status alias works (git plugin)
+- `z <partial-dir>` — zoxide directory jump works
+- Type a long command, see autosuggestion appear (zsh-autosuggestions)
+- Press up-arrow with partial text — history substring search works
+- `cd` into a directory with `.envrc` — direnv loads it
+- `mise current` — mise shows active runtimes
+- `Esc Esc` on a command — sudo prepends (sudo plugin)
+- `jwt --help` — tab completion works (cached completions)
+
+**Step 4: If startup exceeds 500ms, profile**
+
+```bash
+# Add to top of ~/.zshrc temporarily:
+zmodload zsh/zprof
+# Add to bottom:
+zprof
+```
+
+Open a new shell, read the profiling output to identify remaining bottlenecks.
+
+**Step 5: Final commit (if any adjustments needed)**
+
+If verification reveals issues, fix and commit. Otherwise, no commit needed for this task.
+
+---
+
+## Task Dependency Order
+
+```
+Task 0 (baseline) → Tasks 1-6 (independent, any order) → Task 7 (evalcache) → Task 8 (verify)
+```
+
+Tasks 1 through 6 are independent of each other and can be done in any order. Task 7 depends on having a clean state. Task 8 must be last.

--- a/home/.chezmoiscripts/run_onchange_before_14_cache-jwt-completions.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_14_cache-jwt-completions.sh.tmpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Cache JWT CLI completions for ZSH so we don't spawn a subprocess on every shell start.
+# Regenerates when jwt binary changes (chezmoi detects via hash comment below).
+# hash: {{ if lookPath "jwt" }}{{ output "jwt" "--version" | trim }}{{ else }}not-installed{{ end }}
+
+set -euo pipefail
+
+COMP_DIR="$HOME/.zsh_completions"
+mkdir -p "$COMP_DIR"
+
+if command -v jwt >/dev/null 2>&1; then
+  echo "Caching JWT ZSH completions to $COMP_DIR/_jwt..."
+  jwt completion zsh > "$COMP_DIR/_jwt"
+else
+  echo "jwt not found, skipping completion cache"
+fi

--- a/home/.chezmoiscripts/run_onchange_before_15_cache-op-completions.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_15_cache-op-completions.sh.tmpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Cache 1Password CLI completions for ZSH so we don't spawn a subprocess on every shell start.
+# The OMZ 1password plugin runs `op completion zsh` on every shell start, which triggers
+# a 1Password biometric auth prompt. This caches the output instead.
+# Regenerates when op binary changes (chezmoi detects via hash comment below).
+# hash: {{ if lookPath "op" }}{{ output "op" "--version" | trim }}{{ else }}not-installed{{ end }}
+
+set -euo pipefail
+
+COMP_DIR="$HOME/.zsh_completions"
+mkdir -p "$COMP_DIR"
+
+if command -v op >/dev/null 2>&1; then
+  echo "Caching 1Password CLI ZSH completions to $COMP_DIR/_op..."
+  op completion zsh > "$COMP_DIR/_op"
+else
+  echo "op not found, skipping completion cache"
+fi

--- a/home/.chezmoiscripts/run_onchange_before_16_cache-gh-completions.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_16_cache-gh-completions.sh.tmpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Cache GitHub CLI completions for ZSH so we don't spawn a subprocess on every shell start.
+# The OMZ gh plugin runs `gh completion --shell zsh` on every shell start, which triggers
+# a 1Password biometric auth prompt because gh is aliased through `op plugin run -- gh`.
+# Regenerates when gh binary changes (chezmoi detects via hash comment below).
+# hash: {{ if lookPath "gh" }}{{ output "gh" "--version" | trim }}{{ else }}not-installed{{ end }}
+
+set -euo pipefail
+
+COMP_DIR="$HOME/.zsh_completions"
+mkdir -p "$COMP_DIR"
+
+if command -v gh >/dev/null 2>&1; then
+  echo "Caching GitHub CLI ZSH completions to $COMP_DIR/_gh..."
+  gh completion --shell zsh > "$COMP_DIR/_gh"
+else
+  echo "gh not found, skipping completion cache"
+fi

--- a/home/dot_p10k.zsh
+++ b/home/dot_p10k.zsh
@@ -62,7 +62,7 @@
     # laravel_version       # laravel php framework version (https://laravel.com/)
     # java_version          # java version (https://www.java.com/)
     # package               # name@version from package.json (https://docs.npmjs.com/files/package.json)
-    rbenv                   # ruby version from rbenv (https://github.com/rbenv/rbenv)
+    # rbenv                   # ruby version from rbenv (https://github.com/rbenv/rbenv)
     rvm                     # ruby version from rvm (https://rvm.io)
     fvm                     # flutter version management (https://github.com/leoafarias/fvm)
     luaenv                  # lua version from luaenv (https://github.com/cehoffman/luaenv)

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -20,6 +20,9 @@ export POETRY_VIRTUALENVS_IN_PROJECT=true
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 
+# Cached CLI completions (jwt, etc.)
+fpath=(~/.zsh_completions $fpath)
+
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 
@@ -202,10 +205,6 @@ source $ZSH/oh-my-zsh.sh
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
 source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-
-if hash jwt > /dev/null; then
-  source <(jwt completion zsh)
-fi
 
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -103,7 +103,7 @@ plugins=(
   uv
 
   # Cloud CLIs
-  aws
+  # aws  # commented out — re-enable when using AWS completions
   # composer
 
   # Git & GitHub
@@ -144,7 +144,6 @@ plugins=(
   httpie
   # JIRA shortcuts
   # jira
-  sfdx
   sublime
   vscode
   # Adds aliases for searching with Google, Wiki, Bing, YouTube and other popular services.

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -180,8 +180,6 @@ plugins=(
 {{ end }}
 )
 
-autoload -U compinit && compinit
-
 # eval "$(register-python-argcomplete pipx)"
 
 source $ZSH/oh-my-zsh.sh

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -215,11 +215,6 @@ bindkey -M emacs '^N' history-substring-search-down
 
 export PATH="$PATH":"$HOME/.pub-cache/bin"
 
-# Initialize rbenv if it exists
-if command -v rbenv >/dev/null 2>&1; then
-  eval "$(rbenv init - zsh)"
-fi
-
 export PATH="$PATH:$HOME/.local/bin"
 
 # chezmoi customizations 2

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -20,7 +20,7 @@ export POETRY_VIRTUALENVS_IN_PROJECT=true
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 
-# Cached CLI completions (op, jwt, etc.)
+# Cached CLI completions (gh, op, jwt, etc.)
 fpath=(~/.zsh_completions $fpath)
 
 # Path to your oh-my-zsh installation.
@@ -112,7 +112,7 @@ plugins=(
   # Git & GitHub
   git
   forgit
-  gh
+  # gh  # removed — triggers 1Password prompt via op plugin alias; completions cached to ~/.zsh_completions/_gh
 
   # Zsh extensions
   aliases

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -203,9 +203,6 @@ source $ZSH/oh-my-zsh.sh
 
 source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
-# Enable autojump
-[ -f /opt/homebrew/etc/profile.d/autojump.sh ] && . /opt/homebrew/etc/profile.d/autojump.sh
-
 if hash jwt > /dev/null; then
   source <(jwt completion zsh)
 fi

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -20,7 +20,7 @@ export POETRY_VIRTUALENVS_IN_PROJECT=true
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 
-# Cached CLI completions (jwt, etc.)
+# Cached CLI completions (op, jwt, etc.)
 fpath=(~/.zsh_completions $fpath)
 
 # Path to your oh-my-zsh installation.
@@ -128,7 +128,7 @@ plugins=(
   colored-man-pages
   bgnotify
   macos
-  1password
+  # 1password  # removed — triggers biometric prompt on every shell start; op completions cached to ~/.zsh_completions/_op
   # copyfile to copy contents of file to system clipboard
   copyfile
   # Ctrl-O to copy cmd on terminal to clipboard

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -23,6 +23,10 @@ export PATH=$HOME/bin:/usr/local/bin:$PATH
 # Cached CLI completions (gh, op, jwt, etc.)
 fpath=(~/.zsh_completions $fpath)
 
+# Complete aliases as if they were the underlying command (needed for
+# gh aliased through op plugin run -- gh)
+setopt completealiases
+
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -5,22 +5,10 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
-### Alias to list active network interfaces
-alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
-alias ssh-hosts="grep -hE 'Host (.+)' ~/.ssh/config | sed 's/Host //'"
 source ~/.zsh_aliases
 
 # Source Claude Code functions
 source ~/.zsh_claude_code_functions
-
-### Typing '.' will source ~/.zshrc
-function . {
-    if [[ $# -eq 0 ]]; then
-        builtin . ~/.zshrc
-    else
-        builtin . "$@"
-    fi
-}
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -96,8 +96,11 @@ ZSH_ALIAS_FINDER_AUTOMATIC=true
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
+  # Eval caching (must load first)
+  evalcache
+
   # Package managers & tooling
-  mise
+  # mise  # replaced by _evalcache below
   brew
   chezmoi
   uv
@@ -154,7 +157,7 @@ plugins=(
   mvn
 
   # Navigation & environment
-  zoxide
+  # zoxide  # replaced by _evalcache below
   # auto-load .envrc (direnv) and .env (dotenv) per directory
   direnv
   dotenv
@@ -173,6 +176,12 @@ plugins=(
 # eval "$(register-python-argcomplete pipx)"
 
 source $ZSH/oh-my-zsh.sh
+
+# Cached eval for expensive tool init (see evalcache plugin)
+# These replace the OMZ mise and zoxide plugins with cached versions.
+# Run _evalcache_clear after upgrading these tools.
+_evalcache mise activate zsh
+_evalcache zoxide init zsh
 
 # User configuration
 


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Remove redundant work from `.zshrc`: duplicate `compinit` call, duplicate aliases/functions, autojump (replaced by zoxide), rbenv init (replaced by mise)
- Cache CLI completions (jwt, op, gh) to files instead of spawning subprocesses on every shell start — eliminates 1Password biometric prompts triggered by `op` and `gh` OMZ plugins
- Add `evalcache` for `mise` and `zoxide` init, replacing their OMZ plugins with cached eval output (~1ms vs ~30-50ms per tool)
- Remove unused plugins (`sfdx`), comment out `aws`
- Enable `setopt completealiases` so `gh` completions work through the `op plugin run` alias

## Test plan
- [x] Verified `gh <tab>` completions work through 1Password alias
- [x] Verified no 1Password biometric prompt on new shell open
- [x] Verified git aliases (`gst`), zoxide (`z`), mise, direnv, sudo plugin all functional
- [x] Baseline warm startup ~455ms; target <500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)