### PR TITLE
feat(zsh): add Ollama tab completion

### DIFF
--- a/docs/plans/2026-03-01-ollama-zsh-completion-design.md
+++ b/docs/plans/2026-03-01-ollama-zsh-completion-design.md
@@ -1,0 +1,52 @@
+# Ollama ZSH Completion Design
+
+**Date:** 2026-03-01
+**Goal:** Add tab completion for the `ollama` CLI with zero shell startup cost.
+
+---
+
+## Context
+
+Ollama (v0.17.4) has no built-in `completion` subcommand. A community-maintained ZSH completion script exists at [obeone/gist](https://gist.github.com/obeone/9313811fd61a7cbb843e0001a4434c58) that provides subcommand, flag, and dynamic model name completion.
+
+The dotfiles already have `~/.zsh_completions/` in `fpath` (line 24 of `.zshrc`) with three script-generated completions (`_gh`, `_jwt`, `_op`). ZSH discovers completion files lazily, so adding a file to `fpath` costs nothing at startup.
+
+## Approach
+
+**Chezmoi-managed source file.** Add the completion script directly to the chezmoi source directory. Chezmoi deploys it alongside other managed dotfiles.
+
+Alternatives considered and rejected:
+- **Download script from gist:** Adds network dependency to `chezmoi apply`; gist URL could break. The existing `_gh`/`_jwt`/`_op` scripts generate from local binaries, not remote URLs.
+- **Built-in `ollama completion`:** Does not exist as of v0.17.4.
+
+## Changes
+
+### 1. Add completion file
+
+**New file:** `home/dot_zsh_completions/_ollama`
+
+Import the gist completion script. Chezmoi maps this to `~/.zsh_completions/_ollama`.
+
+**What it completes:**
+- Subcommands: `serve`, `create`, `show`, `run`, `pull`, `push`, `list`, `cp`, `rm`, `help`
+- Flags per subcommand (e.g., `--host`, `--timeout`)
+- Dynamic model names via `ollama list` (for `show`, `run`, `pull`, `push`, `cp`, `rm`)
+
+**Dynamic model lookup:** `_fetch_ollama_models()` runs `ollama list 2>/dev/null` at tab-complete time (not at startup). When the server is down, model completion returns nothing; subcommand and flag completion still work.
+
+### 2. No `.zshrc` changes
+
+`fpath=(~/.zsh_completions $fpath)` already exists. No plugins to add, no `source` lines, no `eval` calls.
+
+## Startup Impact
+
+**Zero.** ZSH loads completion functions lazily from `fpath` on first tab-complete, not at shell initialization.
+
+## Verification
+
+```zsh
+# After chezmoi apply:
+ollama <TAB>        # should list subcommands
+ollama run <TAB>    # should list locally available models
+ollama serve -<TAB> # should list flags
+```

--- a/home/dot_zsh_completions/_ollama
+++ b/home/dot_zsh_completions/_ollama
@@ -1,0 +1,116 @@
+#compdef ollama
+
+# Ollama ZSH completion
+# Source: https://gist.github.com/obeone/9313811fd61a7cbb843e0001a4434c58
+# License: MIT
+# Principal contributions by ChatGPT ZSH Expert and obeone.
+
+# Function to fetch and return model names from 'ollama list'
+_fetch_ollama_models() {
+    local -a models
+    local output="$(ollama list 2>/dev/null | sed 's/:/\\:/g')"
+    if [[ -z "$output" ]]; then
+        _message "no models available or 'ollama list' failed"
+        return 1
+    fi
+    models=("${(@f)$(echo "$output" | awk 'NR>1 {print $1}')}")
+    if [[ ${#models} -eq 0 ]]; then
+        _message "no models found"
+        return 1
+    fi
+    _describe 'model names' models
+}
+
+# Main completion function
+_ollama() {
+    local -a commands
+
+    _arguments -C \
+        '1: :->command' \
+        '*:: :->args'
+
+    case $state in
+        command)
+            commands=(
+                'serve:Start ollama'
+                'create:Create a model from a Modelfile'
+                'show:Show information for a model'
+                'run:Run a model'
+                'pull:Pull a model from a registry'
+                'push:Push a model to a registry'
+                'list:List models'
+                'cp:Copy a model'
+                'rm:Remove a model'
+                'help:Help about any command'
+            )
+            _describe -t commands 'ollama command' commands
+        ;;
+        args)
+            case $words[1] in
+                serve)
+                    _arguments \
+                        '--host[Specify the host and port]:host and port:' \
+                        '--origins[Set allowed origins]:origins:' \
+                        '--models[Path to the models directory]:path:_directories' \
+                        '--keep-alive[Duration to keep models in memory]:duration:'
+                ;;
+                create)
+                    _arguments \
+                        '-f+[Specify the file name]:file:_files'
+                ;;
+                show)
+                    _arguments \
+                        '--license[Show license of a model]' \
+                        '--modelfile[Show Modelfile of a model]' \
+                        '--parameters[Show parameters of a model]' \
+                        '--system[Show system message of a model]' \
+                        '--template[Show template of a model]' \
+                        '*::model:->model'
+                    if [[ $state == model ]]; then
+                        _fetch_ollama_models
+                    fi
+                ;;
+                run)
+                    _arguments \
+                        '--format[Specify the response format]:format:' \
+                        '--insecure[Use an insecure registry]' \
+                        '--nowordwrap[Disable word wrap]' \
+                        '--verbose[Show verbose output]' \
+                        '*::model and prompt:->model_and_prompt'
+                    if [[ $state == model_and_prompt ]]; then
+                        _fetch_ollama_models
+                        _message "enter prompt"
+                    fi
+                ;;
+                pull|push)
+                    _arguments \
+                        '--insecure[Use an insecure registry]' \
+                        '*::model:->model'
+                    if [[ $state == model ]]; then
+                        _fetch_ollama_models
+                    fi
+                ;;
+                list)
+                    _message "no additional arguments for list"
+                ;;
+                cp)
+                    _arguments \
+                        '1:source model:_fetch_ollama_models' \
+                        '2:target model:_fetch_ollama_models'
+                ;;
+                rm)
+                    _arguments \
+                        '*::models:->models'
+                    if [[ $state == models ]]; then
+                        _fetch_ollama_models
+                    fi
+                ;;
+                help)
+                    _message "no additional arguments for help"
+                ;;
+            esac
+        ;;
+    esac
+}
+
+_ollama


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Add chezmoi-managed ZSH completion for the `ollama` CLI (`home/dot_zsh_completions/_ollama`)
- Completes subcommands (`serve`, `run`, `pull`, `push`, `show`, `list`, `cp`, `rm`, `create`, `help`), per-command flags, and dynamic model names via `ollama list`
- Zero shell startup cost — ZSH loads completion lazily from `fpath` on first tab-complete
- Includes design doc at `docs/plans/2026-03-01-ollama-zsh-completion-design.md`

## Test plan
- [ ] Open a fresh terminal and run `ollama <TAB>` — should list all subcommands
- [ ] Run `ollama serve --<TAB>` — should show `--host`, `--origins`, `--models`, `--keep-alive`
- [ ] Run `ollama run <TAB>` — should list locally available models (requires ollama server running)
- [ ] Run `time zsh -i -c exit` — startup time should be unaffected (well under 500ms)

🤖 Generated with [Claude Code](https://claude.ai/code)