### PR TITLE
feat(claude): add hook to prevent unsigned git commits

### DIFF
--- a/home/dot_claude/hooks/executable_prevent_unsigned_commits.py
+++ b/home/dot_claude/hooks/executable_prevent_unsigned_commits.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env uv run
+import json
+import re
+import sys
+
+# Block git commit commands that disable GPG signing.
+# Commits in this environment are signed via 1Password SSH;
+# bypassing signing is never intentional.
+BLOCK_PATTERNS = [
+    (
+        r"--no-gpg-sign",
+        "Unsigned commits are not allowed. Remove --no-gpg-sign to sign via 1Password SSH.",
+    ),
+    (
+        r"-c\s+commit\.gpgsign=false",
+        "Unsigned commits are not allowed. Remove -c commit.gpgsign=false to sign via 1Password SSH.",
+    ),
+]
+
+
+def strip_message_content(cmd: str) -> str:
+    """Remove commit message content so flags inside messages don't false-positive.
+
+    Strips:
+    - Heredoc bodies (<<'EOF' ... EOF  or  <<EOF ... EOF)
+    - Inline -m "..." or -m '...' arguments
+    """
+    # Strip heredoc bodies (content between <<'DELIM' or <<DELIM and the delimiter)
+    cmd = re.sub(r"<<'?(\w+)'?.*?\n.*?\1", "", cmd, flags=re.DOTALL)
+    # Strip -m "..." (double-quoted message)
+    cmd = re.sub(r'''-m\s+"[^"]*"''', "-m MSG", cmd)
+    # Strip -m '...' (single-quoted message)
+    cmd = re.sub(r"""-m\s+'[^']*'""", "-m MSG", cmd)
+    return cmd
+
+
+try:
+    input_data = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+    sys.exit(1)
+
+tool_name = input_data.get("tool_name", "")
+tool_input = input_data.get("tool_input", {})
+command = tool_input.get("command", "")
+
+# Only inspect Bash commands containing "git commit" (or "git ... commit")
+if tool_name != "Bash" or not command or not re.search(r"\bgit\b.*\bcommit\b", command):
+    sys.exit(0)
+
+# Strip message content to avoid false positives from flags mentioned in commit messages
+command_flags = strip_message_content(command)
+
+# Check for signing bypass attempts
+for pattern, message in BLOCK_PATTERNS:
+    if re.search(pattern, command_flags):
+        print(f"BLOCKED: {message}", file=sys.stderr)
+        sys.exit(2)
+
+sys.exit(0)

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/prevent_unsigned_commits.py"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "explanatory-output-style@claude-code-plugins": true,
     "code-review@claude-code-plugins": true,


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Adds a `PreToolUse` hook (`prevent_unsigned_commits.py`) that intercepts `git commit` commands in the Bash tool and blocks those that disable GPG signing (`--no-gpg-sign` or `-c commit.gpgsign=false`)
- Registers the hook in `settings.json` under `hooks.PreToolUse` with a `Bash` matcher
- Includes message-content stripping (heredocs and inline `-m` args) to avoid false positives when commit messages reference the blocked flags
- Follows the existing `bash_enforce_ripgrep.py` hook pattern: Python via `uv run`, JSON stdin, `exit 2` to block

## Test plan

All tests passed via a Python test harness piping JSON to the hook directly:

| # | Input | Expected | Result |
|---|-------|----------|--------|
| 1 | `git commit --no-gpg-sign -m 'test'` | BLOCKED (exit 2) | ✅ BLOCKED |
| 2 | `git -c commit.gpgsign=false commit -m 'test'` | BLOCKED (exit 2) | ✅ BLOCKED |
| 3 | `git commit -m 'normal'` | ALLOWED (exit 0) | ✅ ALLOWED |
| 4 | `ls -la` (non-git command) | ALLOWED (exit 0) | ✅ ALLOWED |
| 5 | `git commit -m "docs about --no-gpg-sign"` (flag inside inline msg) | ALLOWED (exit 0) | ✅ ALLOWED |
| 6 | `git commit -m "$(cat <<'EOF'..--no-gpg-sign..EOF)"` (flag inside heredoc) | ALLOWED (exit 0) | ✅ ALLOWED |

### Reproduce locally

```bash
chezmoi apply
# Verify deployment
ls -la ~/.claude/hooks/prevent_unsigned_commits.py

# Run test harness (uses string concatenation to avoid self-referential hook blocking)
cat > /tmp/test_hook.py << 'PYEOF'
#!/usr/bin/env python3
import subprocess, json

HOOK = "/Users/omair/.claude/hooks/prevent_unsigned_commits.py"
flag = "--no-gpg" + "-sign"
cflag = "commit.gpg" + "sign=false"

def test(label, cmd, expect):
    data = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
    r = subprocess.run([HOOK], input=data, capture_output=True, text=True)
    status = "BLOCKED" if r.returncode == 2 else "ALLOWED"
    ok = "pass" if r.returncode == expect else "FAIL"
    print(f"  {ok} {status:8s} | {label}")

test("actual flag",         f"git commit {flag} -m 'test'", 2)
test("-c override",         f"git -c {cflag} commit -m 'test'", 2)
test("normal commit",       "git commit -m 'normal'", 0)
test("non-git command",     "ls -la", 0)
test("flag in inline msg",  f'git commit -m "docs about {flag}"', 0)
test("flag in heredoc msg", f"git commit -m \"$(cat <<'EOF'\nAbout {flag}\nEOF\n)\"", 0)
PYEOF
python3 /tmp/test_hook.py
```

🤖 Generated with [Claude Code](https://claude.ai/code)