### PR TITLE
feat(espanso): add espanso text expander cask and initial config

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -21,6 +21,7 @@
             "claude-code",                 # Anthropic Claude Code CLI
             "daisydisk",                   # Disk space analyzer
             "cleanshot",                   # Advanced screenshot and screen recording
+            "espanso",                     # Cross-platform text expander
             "forklift3",                   # File manager and FTP client
             "ghostty",                     # Terminal emulator
             "google-chrome",               # Google web browser

--- a/home/dot_config/espanso/config/default.yml
+++ b/home/dot_config/espanso/config/default.yml
@@ -1,0 +1,52 @@
+# espanso configuration file
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/dev/schemas/config.schema.json
+
+# For a complete introduction, visit the official docs at: https://espanso.org/docs/
+
+# You can use this file to define the global configuration options for espanso.
+# These are the parameters that will be used by default on every application,
+# but you can also override them on a per-application basis.
+
+# To make customization easier, this file contains some of the commonly used
+# parameters. Feel free to uncomment and tune them to fit your needs!
+
+# --- Toggle key
+
+# Customize the key used to disable and enable espanso (when double tapped)
+# Available options: CTRL, SHIFT, ALT, CMD, OFF
+# You can also specify the key variant, such as LEFT_CTRL, RIGHT_SHIFT, etc...
+# toggle_key: ALT
+# You can also disable the toggle key completely with
+# toggle_key: OFF
+
+# --- Injection Backend
+
+# Espanso supports multiple ways of injecting text into applications. Each of
+# them has its quirks, therefore you may want to change it if you are having problems.
+# By default, espanso uses the "Auto" backend which should work well in most cases,
+# but you may want to try the "Clipboard" or "Inject" backend in case of issues.
+# backend: Clipboard
+
+# --- Auto-restart
+
+# Enable/disable the config auto-reload after a file change is detected.
+# auto_restart: false
+
+# --- Clipboard threshold
+
+# Because injecting long texts char-by-char is a slow operation, espanso automatically
+# uses the clipboard if the text is longer than 'clipboard_threshold' characters.
+# clipboard_threshold: 100
+
+# --- Regex Buffer Size
+
+# The maximum number of characters to hold in memory for regex triggers.
+# This value determines the maximum length of a regex trigger that can be
+# matched by espanso and by default have 30 chars.
+# It's advisable to keep this value reasonably low.
+# You might want to increase this value if you have very long triggers,
+# at the cost of higher memory usage.
+# max_regex_buffer_size: 30
+
+# For a list of all the available options, visit the official docs at: https://espanso.org/docs/

--- a/home/dot_config/espanso/match/base.yml
+++ b/home/dot_config/espanso/match/base.yml
@@ -1,0 +1,40 @@
+# espanso match file
+
+# For a complete introduction, visit the official docs at: https://espanso.org/docs/
+
+# You can use this file to define the base matches (aka snippets)
+# that will be available in every application when using espanso.
+
+# Matches are substitution rules: when you type the "trigger" string
+# it gets replaced by the "replace" string.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/dev/schemas/match.schema.json
+
+matches:
+  # Simple text replacement
+  - trigger: ":espanso"
+    replace: "Hi there!"
+
+  # NOTE: espanso uses YAML to define matches, so pay attention to the indentation!
+
+  # But matches can also be dynamic:
+
+  # Print the current date
+  - trigger: ":date"
+    replace: "{{mydate}}"
+    vars:
+      - name: mydate
+        type: date
+        params:
+          format: "%m/%d/%Y"
+
+  # Print the output of a shell command
+  - trigger: ":shell"
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: "echo 'Hello from your shell'"
+
+  # And much more! For more information, visit the docs: https://espanso.org/docs/


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary

- Adds `espanso` (cross-platform text expander) to personal Homebrew casks in `packages.toml`
- Commits chezmoi-managed espanso config directory with default global configuration (`config/default.yml`)
- Adds base match file (`match/base.yml`) with starter snippets (date, shell output, placeholder)
- Adds `match/packages/.keep` placeholder for the espanso packages directory

## Test plan

- Run `chezmoi apply` and verify espanso is installed via `brew list espanso`
- Confirm `~/.config/espanso/config/default.yml` and `~/.config/espanso/match/base.yml` are present
- Launch espanso (`espanso start`) and test the `:date` trigger to confirm expansions work

🤖 Generated with [Claude Code](https://claude.ai/code)