### PR TITLE
fix(zsh): replace HOMEBREW_NO_AUTO_UPDATE with daily auto-update throttle

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -10,7 +10,7 @@ source ~/.zsh_aliases
 # Source Claude Code functions
 source ~/.zsh_claude_code_functions
 
-export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_AUTO_UPDATE_SECS=86400
 
 # Python SSL Certs
 # export SSL_CERT_FILE=~/all_mac_certs.pem


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Replace `HOMEBREW_NO_AUTO_UPDATE=1` with `HOMEBREW_AUTO_UPDATE_SECS=86400` in `.zshrc`
- **Root cause:** The hard disable prevented Homebrew from ever self-updating, causing portable-ruby version drift. On macOS Tahoe (26.x), the stale portable-ruby 3.1.4 doesn't recognize macOS version "26.3", breaking all `brew` commands with `MacOSVersion::Error`
- **Fix:** Throttle auto-updates to once per day instead of disabling them entirely — keeps Homebrew current enough for cutting-edge macOS while preserving the speed benefit for 99% of invocations

## Test plan
- [ ] Run `chezmoi apply` (or `cma`) and confirm `~/.zshrc` now contains `HOMEBREW_AUTO_UPDATE_SECS=86400`
- [ ] Open a new shell and verify `echo $HOMEBREW_AUTO_UPDATE_SECS` returns `86400`
- [ ] Verify `echo $HOMEBREW_NO_AUTO_UPDATE` is unset
- [ ] Run `brew upgrade` and confirm it no longer errors with `unknown or unsupported macOS version`

🤖 Generated with [Claude Code](https://claude.ai/code)