### PR TITLE
feat(claude): switch Claude Code to native installer

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -18,7 +18,6 @@
             "beyond-compare",              # File and folder comparison tool
             "chatgpt",                     # OpenAI ChatGPT desktop app
             "claude",                      # Anthropic Claude desktop app
-            "claude-code",                 # Anthropic Claude Code CLI
             "daisydisk",                   # Disk space analyzer
             "cleanshot",                   # Advanced screenshot and screen recording
             "espanso",                     # Cross-platform text expander

--- a/home/.chezmoiscripts/run_before_10_install-claude-code-native.sh.tmpl
+++ b/home/.chezmoiscripts/run_before_10_install-claude-code-native.sh.tmpl
@@ -2,19 +2,7 @@
 #!/bin/bash
 set -eufo pipefail
 
-# Add Homebrew to PATH (required on Apple Silicon for migration check)
-if [[ -f /opt/homebrew/bin/brew ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-fi
-
 CLAUDE_BIN="$HOME/.local/bin/claude"
-
-# One-time migration: remove Homebrew cask if still installed
-# TODO: Remove migration block once all machines have transitioned from cask
-if brew list --cask claude-code >/dev/null 2>&1; then
-  echo "Removing Homebrew cask claude-code in favour of native install..."
-  brew uninstall --cask claude-code
-fi
 
 # Install Claude Code natively if not already present
 if [[ ! -x "$CLAUDE_BIN" ]]; then

--- a/home/.chezmoiscripts/run_before_10_install-claude-code-native.sh.tmpl
+++ b/home/.chezmoiscripts/run_before_10_install-claude-code-native.sh.tmpl
@@ -1,0 +1,24 @@
+{{- if (eq .chezmoi.os "darwin") -}}
+#!/bin/bash
+set -eufo pipefail
+
+# Add Homebrew to PATH (required on Apple Silicon for migration check)
+if [[ -f /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+CLAUDE_BIN="$HOME/.local/bin/claude"
+
+# One-time migration: remove Homebrew cask if still installed
+# TODO: Remove migration block once all machines have transitioned from cask
+if brew list --cask claude-code >/dev/null 2>&1; then
+  echo "Removing Homebrew cask claude-code in favour of native install..."
+  brew uninstall --cask claude-code
+fi
+
+# Install Claude Code natively if not already present
+if [[ ! -x "$CLAUDE_BIN" ]]; then
+  echo "Installing Claude Code via native installer..."
+  curl -fsSL https://claude.ai/install.sh | bash
+fi
+{{ end }}


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Remove `claude-code` Homebrew cask from `packages.toml` — Claude Code will no longer be installed via `brew bundle`
- Add `run_before_10_install-claude-code-native.sh.tmpl` chezmoi script that:
  - Migrates away from the Homebrew cask (one-time uninstall if still present)
  - Installs Claude Code via the native installer (`curl -fsSL https://claude.ai/install.sh | bash`) if `~/.local/bin/claude` is not present
  - Self-heals on every `chezmoi apply` (reinstalls if binary is deleted)

## Context
Anthropic now recommends the native installer which is self-contained, auto-updates, and requires no runtime dependencies. The native binary installs to `~/.local/bin/claude` which is already on PATH.

## Manual follow-up
After applying, remove the duplicate mise/npm install:
```bash
mise uninstall npm:@anthropic-ai/claude-code
# Then edit ~/.config/mise/config.toml and remove the claude-code line
```

## Test plan
- [ ] `chezmoi diff` — confirm `claude-code` is gone from generated Brewfile, new script appears
- [ ] `chezmoi apply` — script should be a no-op (native binary already present at `~/.local/bin/claude`)
- [ ] `which claude` → resolves to `~/.local/bin/claude`
- [ ] `claude --version` → confirms working install

🤖 Generated with [Claude Code](https://claude.com/claude-code)