### PR TITLE
chore(mise): add mise config to chezmoi and remove Claude Code

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -1,0 +1,17 @@
+[tools]
+# Node runtime (required by npm backend)
+node = "lts"
+
+# Python CLI tools (pipx backend uses uv when available)
+"pipx:showboat" = "latest"
+"pipx:rodney" = "latest"
+
+# Python runtime
+python = "3.13"
+# Work tools
+"npm:@arizeai/phoenix-cli" = "latest"
+java = ["temurin-24", "temurin-21"]
+
+
+[settings]
+trusted_config_paths = ["."]


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Adds `~/.config/mise/config.toml` to chezmoi management so it is tracked and reproducible across machines
- Removes `npm:@anthropic-ai/claude-code` from mise, completing the switch to the native Claude Code installer (see #48)

## Test plan
- [ ] Run `chezmoi diff` to verify the mise config renders correctly
- [ ] Run `chezmoi apply` to deploy the config
- [ ] Confirm `mise ls` no longer shows `npm:@anthropic-ai/claude-code`
- [ ] Verify other mise-managed tools (node, python, java, pipx tools) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)