### PR TITLE
feat(slack): add agent-slack via mise and Claude skill files

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -78,7 +78,6 @@
             "moar",                        # Pager with syntax highlighting
             "nmap",                        # Network mapper
             "oha",                         # HTTP load generator
-            "pnpm",                        # Fast, disk-efficient package manager
             "uv",                          # Fast Python package manager and tool runner
             "postgresql@14",               # PostgreSQL database
             "python@3.13",                 # Python programming language

--- a/home/dot_claude/skills/agent-slack/SKILL.md
+++ b/home/dot_claude/skills/agent-slack/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: agent-slack
+description: |
+  Slack automation CLI for AI agents. Use when:
+  - Reading a Slack message or thread (given a URL or channel+ts)
+  - Browsing recent channel messages / channel history
+  - Downloading Slack attachments (snippets, images, files) to local paths
+  - Searching Slack messages or files
+  - Sending, editing, or deleting a message; adding/removing reactions
+  - Listing channels/conversations; creating channels and inviting users
+  - Fetching a Slack canvas as markdown
+  - Looking up Slack users
+  - Opening DM or group DM channels
+  Triggers: "slack message", "slack thread", "slack URL", "slack link", "read slack", "reply on slack", "search slack", "channel history", "recent messages", "channel messages", "latest messages"
+---
+
+# Slack automation with `agent-slack`
+
+`agent-slack` is a CLI binary installed on `$PATH`. Invoke it directly (e.g. `agent-slack user list`).
+If installed via Nix flake only, run commands with `nix run github:stablyai/agent-slack -- <args>`.
+
+## Quick start (auth)
+
+Authentication is automatic on macOS and Windows (Slack Desktop first, then Chrome/Firefox fallbacks on macOS).
+
+If credentials aren't available, run one of:
+
+- Slack Desktop import (macOS/Windows):
+
+```bash
+agent-slack auth import-desktop
+agent-slack auth test
+```
+
+- Chrome fallback:
+
+```bash
+agent-slack auth import-chrome
+agent-slack auth test
+```
+
+- Firefox fallback:
+
+```bash
+agent-slack auth import-firefox
+agent-slack auth test
+```
+
+- Or set env vars (browser tokens; avoid pasting these into chat logs):
+
+```bash
+export SLACK_TOKEN="xoxc-..."
+export SLACK_COOKIE_D="xoxd-..."
+agent-slack auth test
+```
+
+- Or set a standard token:
+
+```bash
+export SLACK_TOKEN="xoxb-..."  # or xoxp-...
+agent-slack auth test
+```
+
+Check configured workspaces:
+
+```bash
+agent-slack auth whoami
+```
+
+## Canonical workflow (given a Slack message URL)
+
+1. Fetch a single message (plus thread summary, if any):
+
+```bash
+agent-slack message get "https://workspace.slack.com/archives/C123/p1700000000000000"
+```
+
+2. If you need the full thread:
+
+```bash
+agent-slack message list "https://workspace.slack.com/archives/C123/p1700000000000000"
+```
+
+## Browse recent channel messages
+
+To see what's been posted recently in a channel (channel history):
+
+```bash
+agent-slack message list "#general" --limit 20
+agent-slack message list "C0123ABC" --limit 10
+agent-slack message list "#general" --with-reaction eyes --oldest "1770165109.000000" --limit 20
+agent-slack message list "#general" --without-reaction dart --oldest "1770165109.000000" --limit 20
+```
+
+This returns the most recent messages in chronological order. Use `--limit` to control how many (default 25).
+When using `--with-reaction` or `--without-reaction`, you must also pass `--oldest` to bound scanning.
+
+## Attachments (snippets/images/files)
+
+`message get/list` and `search` auto-download attachments and include absolute paths in JSON output (typically under `message.files[].path` / `files[].path`).
+
+## Draft a message (browser editor)
+
+Opens a Slack-like rich-text editor in the browser for composing messages with formatting toolbar (bold, italic, strikethrough, links, lists, quotes, code, code blocks). After sending, shows a "View in Slack" link.
+
+```bash
+agent-slack message draft "#general"
+agent-slack message draft "#general" "initial text"
+agent-slack message draft "https://workspace.slack.com/archives/C123/p1700000000000000"
+```
+
+## Send, edit, delete, or react
+
+```bash
+agent-slack message send "https://workspace.slack.com/archives/C123/p1700000000000000" "I can take this."
+agent-slack message send "#alerts-staging" "here's the report" --attach ./report.md
+agent-slack message edit "https://workspace.slack.com/archives/C123/p1700000000000000" "I can take this today."
+agent-slack message delete "https://workspace.slack.com/archives/C123/p1700000000000000"
+
+# Bullet lists are auto-detected and rendered as native Slack rich text:
+agent-slack message send "#general" "Here's the plan:
+- Step 1: do the thing
+- Step 2: verify it worked
+  - Sub-step: check logs"
+agent-slack message react add "https://workspace.slack.com/archives/C123/p1700000000000000" "eyes"
+agent-slack message react remove "https://workspace.slack.com/archives/C123/p1700000000000000" "eyes"
+```
+
+Channel mode for edit/delete requires `--ts`:
+
+```bash
+agent-slack message edit "#general" "Updated text" --workspace "myteam" --ts "1770165109.628379"
+agent-slack message delete "#general" --workspace "myteam" --ts "1770165109.628379"
+```
+
+Attach options for `message send`:
+
+- `--attach <path>` upload a local file (repeatable)
+
+## List channels + create/invite users
+
+```bash
+agent-slack channel list
+agent-slack channel list --user "@alice" --limit 50
+agent-slack channel list --all --limit 100
+agent-slack channel new --name "incident-war-room"
+agent-slack channel new --name "incident-leads" --private
+agent-slack channel invite --channel "incident-war-room" --users "U01AAAA,@alice,bob@example.com"
+agent-slack channel invite --channel "incident-war-room" --users "partner@vendor.com" --external
+agent-slack channel invite --channel "incident-war-room" --users "partner@vendor.com" --external --allow-external-user-invites
+```
+
+For `--external`, invite targets must be emails. By default, invitees are external-limited; add
+`--allow-external-user-invites` to allow them to invite other users.
+
+## Search (messages + files)
+
+Prefer channel-scoped search for reliability:
+
+```bash
+agent-slack search all "smoke tests failed" --channel "#alerts" --after 2026-01-01 --before 2026-02-01
+agent-slack search messages "stably test" --user "@alice" --channel general
+agent-slack search files "testing" --content-type snippet --limit 10
+```
+
+## Multi-workspace guardrail (important)
+
+If you have multiple workspaces configured and you use a channel **name** (`#general` / `general`), pass `--workspace` (or set `SLACK_WORKSPACE_URL`) to avoid ambiguity:
+
+```bash
+agent-slack message get "#general" --workspace "https://myteam.slack.com" --ts "1770165109.628379"
+agent-slack message get "#general" --workspace "myteam" --ts "1770165109.628379"
+```
+
+## DM / group DM channels
+
+Get the channel ID for a DM or group DM, useful for sending messages to a group of users:
+
+```bash
+agent-slack user dm-open @alice @bob
+agent-slack user dm-open U01AAAA U02BBBB U03CCCC
+```
+
+## Canvas + Users
+
+```bash
+agent-slack canvas get "https://workspace.slack.com/docs/T123/F456"
+agent-slack user list --workspace "https://workspace.slack.com" --limit 100
+agent-slack user get "@alice" --workspace "https://workspace.slack.com"
+```
+
+## References
+
+- [references/commands.md](references/commands.md): full command map + all flags
+- [references/targets.md](references/targets.md): URL vs `#channel` targeting rules
+- [references/output.md](references/output.md): JSON output shapes + download paths

--- a/home/dot_claude/skills/agent-slack/references/commands.md
+++ b/home/dot_claude/skills/agent-slack/references/commands.md
@@ -1,0 +1,128 @@
+# `agent-slack` command map (reference)
+
+Run `agent-slack --help` (or `agent-slack <command> --help`) for the full option list.
+
+## Auth
+
+- `agent-slack auth whoami` — show configured workspaces + token sources (secrets redacted)
+- `agent-slack auth test [--workspace <url-or-unique-substring>]` — verify credentials (`auth.test`)
+- `agent-slack auth import-desktop` — import browser-style creds from Slack Desktop (macOS/Windows)
+- `agent-slack auth import-chrome` — import creds from Chrome (macOS)
+- `agent-slack auth import-firefox` — import creds from Firefox profile storage (macOS/Linux)
+- `agent-slack auth parse-curl` — read a copied Slack cURL command from stdin and save creds
+- `agent-slack auth add --workspace-url <url> [--token <xoxb/xoxp> | --xoxc <xoxc> --xoxd <xoxd>]`
+- `agent-slack auth set-default <workspace-url>`
+- `agent-slack auth remove <workspace-url>`
+
+## Messages / threads
+
+- `agent-slack message get <target>`
+  - `<target>`: Slack message URL OR `#channel`/`channel`/channel id (`C...`) (see `targets.md`)
+  - Options:
+    - `--workspace <url-or-unique-substring>` (required when using a channel _name_ across multiple workspaces)
+    - `--ts <seconds>.<micros>` (required when targeting a channel)
+    - `--thread-ts <seconds>.<micros>` (optional hint for thread permalinks)
+    - `--max-body-chars <n>` (default `8000`, `-1` unlimited)
+    - `--include-reactions`
+
+- `agent-slack message list <target>`
+  - Lists recent channel messages (channel history), or fetches all thread replies
+  - **Channel history** (default when targeting a channel without `--thread-ts`):
+    - `agent-slack message list "#general"` — latest 25 messages
+    - `agent-slack message list "#general" --limit 50` — latest 50 messages
+  - **Thread mode** (when `--thread-ts` or `--ts` is provided, or target is a message URL):
+    - `agent-slack message list "<url>"` — all replies in that thread
+    - `agent-slack message list "#general" --thread-ts "1770165109.000001"` — thread replies
+  - Options:
+    - `--workspace <url-or-unique-substring>` (same rules as above)
+    - `--thread-ts <seconds>.<micros>` (switches to thread mode; fetches replies)
+    - `--ts <seconds>.<micros>` (resolve a message to its thread)
+    - `--limit <n>` (default `25`, max `200`; channel history mode only)
+    - `--oldest <ts>` (only messages after this ts; channel history mode)
+    - `--latest <ts>` (only messages before this ts; channel history mode)
+    - `--with-reaction <emoji>` (repeatable; include only messages that have this reaction; channel history mode; requires `--oldest`)
+    - `--without-reaction <emoji>` (repeatable; include only messages that do not have this reaction; channel history mode; requires `--oldest`)
+    - `--max-body-chars <n>` (default `8000`, `-1` unlimited)
+    - `--include-reactions`
+
+- `agent-slack message draft <target> [text]`
+  - Opens a Slack-like WYSIWYG editor in the browser for composing and sending a message.
+  - Formatting toolbar: bold, italic, strikethrough, links, numbered/bulleted lists, quotes, inline code, code blocks.
+  - Toggle between rich-text editing and raw mrkdwn source view.
+  - After sending, shows a "View in Slack" permalink to the posted message.
+  - If `<target>` is a Slack message URL, the draft will reply in that thread.
+  - Options:
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
+
+- `agent-slack message send <target> <text>`
+  - If `<target>` is a Slack message URL, replies in that message's thread.
+  - Otherwise posts to the channel/DM.
+  - Bullet lists (`- `, `* `, `• `, `1. `, etc.) are automatically converted to Slack's native rich text format, so recipients see real editable bullets instead of plain-text dashes.
+  - Options:
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--thread-ts <seconds>.<micros>` (optional, channel mode only)
+    - `--attach <path>` (repeatable; upload local files as attachments)
+
+- `agent-slack message edit <target> <text>`
+  - URL target edits that exact message.
+  - Channel target requires `--ts`.
+  - Options:
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--ts <seconds>.<micros>` (required for channel targets)
+
+- `agent-slack message delete <target>`
+  - URL target deletes that exact message.
+  - Channel target requires `--ts`.
+  - Options:
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--ts <seconds>.<micros>` (required for channel targets)
+
+- `agent-slack message react add <target> <emoji>`
+- `agent-slack message react remove <target> <emoji>`
+  - Options (channel mode):
+    - `--workspace <url-or-unique-substring>` (needed for channel _names_ across multiple workspaces)
+    - `--ts <seconds>.<micros>` (required for channel targets)
+
+## Channels
+
+- `agent-slack channel list [--workspace <url-or-unique-substring>] [--user <U...|@handle|handle> | --all] [--limit <n>] [--cursor <cursor>]`
+  - Default mode calls `users.conversations` for the current user.
+  - `--user` resolves handles/ids and lists conversations for that user.
+  - `--all` switches to `conversations.list` (mutually exclusive with `--user`).
+  - Returns one page and optional `next_cursor`; pass `--cursor` to continue.
+- `agent-slack channel new --name <name> [--private] [--workspace <url-or-unique-substring>]`
+- `agent-slack channel invite --channel <id|name> --users "<U...,@handle,email,...>" [--workspace <url-or-unique-substring>]`
+  - Internal invite (default): resolves users (`U...`, `@handle`, `handle`, `email`) and uses `conversations.invite`
+  - External invite: add `--external` (email targets only) to use `conversations.inviteShared`
+  - Optional: `--allow-external-user-invites` sets `external_limited=false` for external invites
+
+## Search
+
+- `agent-slack search all <query>` — messages + files (default)
+- `agent-slack search messages <query>`
+- `agent-slack search files <query>`
+
+Common options:
+
+- `--workspace <url-or-unique-substring>` (recommended when using channel names across multiple workspaces)
+- `--channel <channel...>` repeatable (`#name`, `name`, or id)
+- `--user <@name|name|U...>`
+- `--after YYYY-MM-DD`
+- `--before YYYY-MM-DD`
+- `--content-type any|text|image|snippet|file`
+- `--limit <n>` (default `20`)
+- `--max-content-chars <n>` (default `4000`, `-1` unlimited; messages only)
+
+## Canvas
+
+- `agent-slack canvas get <canvas-url-or-id>`
+  - Options:
+    - `--workspace <url-or-unique-substring>` (required when passing an id and multiple workspaces)
+    - `--max-chars <n>` (default `20000`, `-1` unlimited)
+
+## Users
+
+- `agent-slack user list [--workspace <url-or-unique-substring>] [--limit <n>] [--cursor <cursor>] [--include-bots]`
+- `agent-slack user get <U...|@handle|handle> [--workspace <url-or-unique-substring>]`
+- `agent-slack user dm-open <users...> [--workspace <url-or-unique-substring>]` — get DM or group DM channel ID for one or more users (max 8)

--- a/home/dot_claude/skills/agent-slack/references/output.md
+++ b/home/dot_claude/skills/agent-slack/references/output.md
@@ -1,0 +1,62 @@
+# Output + downloads (reference)
+
+## Output format
+
+All commands print JSON to stdout.
+
+- Empty values are pruned (`null`, `[]`, `{}` are removed where possible).
+- `auth whoami` redacts secrets in its output.
+
+## Message shapes (high-level)
+
+- `message get` returns:
+  - `message: { ... }`
+  - `thread?: { ts, length }` (summary only; present when threaded)
+
+- `message list` returns:
+  - `messages: [ ... ]` (the full thread)
+  - Messages are compact and omit redundant fields on each item where possible.
+
+Use `--max-body-chars` to cap message bodies for token budget control.
+
+## Search shapes (high-level)
+
+- `search messages|all` returns `messages: [ ... ]`
+- `search files|all` returns `files: [ ... ]`
+
+Use `--max-content-chars` (messages) and `--limit` to control size.
+
+## Channel shapes (high-level)
+
+- `channel list` returns:
+  - `channels: [ ... ]`
+  - `next_cursor?: string` (present when more pages are available)
+
+- `channel new` returns:
+  - `channel: { id, name, is_private }`
+
+- `channel invite` returns:
+  - Internal invite mode:
+    - `channel_id`
+    - `invited_user_ids: [ ... ]`
+    - `already_in_channel_user_ids?: [ ... ]`
+    - `unresolved_users?: [ ... ]`
+  - External invite mode (`--external`):
+    - `channel_id`
+    - `external: true`
+    - `external_limited: boolean`
+    - `invited_emails: [ ... ]`
+    - `already_invited_emails?: [ ... ]`
+    - `invalid_external_targets?: [ ... ]`
+
+## Attachment downloads
+
+Attachments are downloaded to an agent-friendly temp directory and returned as absolute paths in output.
+
+Default download root:
+
+- `~/.agent-slack/tmp/downloads/`
+
+If `XDG_RUNTIME_DIR` is set, downloads live under:
+
+- `$XDG_RUNTIME_DIR/agent-slack/tmp/downloads/`

--- a/home/dot_claude/skills/agent-slack/references/targets.md
+++ b/home/dot_claude/skills/agent-slack/references/targets.md
@@ -1,0 +1,72 @@
+# Targets: URL vs channel (reference)
+
+`agent-slack` accepts either a **Slack message URL** (preferred) or a **channel reference**.
+
+## Preferred: Slack message URL
+
+Use the message permalink whenever you have it:
+
+```text
+https://<workspace>.slack.com/archives/<channel_id>/p<digits>[?thread_ts=...]
+```
+
+Examples:
+
+- `agent-slack message get "<url>"`
+- `agent-slack message list "<url>"`
+- `agent-slack message send "<url>" "reply text"`
+- `agent-slack message edit "<url>" "updated text"`
+- `agent-slack message delete "<url>"`
+- `agent-slack message react add "<url>" "eyes"`
+
+## Channel targets (when you don't have a URL)
+
+Channel references can be:
+
+- channel name: `#general` or `general`
+- channel id: `C...` (or `G...`/`D...`)
+
+### `message get` by channel + `--ts`
+
+```bash
+agent-slack message get "#general" --ts "1770165109.628379"
+```
+
+### `message list` by channel + `--thread-ts` (or `--ts` to resolve)
+
+```bash
+agent-slack message list "#general" --thread-ts "1770165109.000001"
+agent-slack message list "#general" --ts "1770165109.628379"  # resolves to its thread
+agent-slack message list "#general" --without-reaction dart --limit 20  # channel history filter
+```
+
+### Reactions by channel + `--ts`
+
+```bash
+agent-slack message react add "#general" "eyes" --ts "1770165109.628379"
+```
+
+### Edit/delete by channel + `--ts`
+
+```bash
+agent-slack message edit "#general" "updated text" --ts "1770165109.628379"
+agent-slack message delete "#general" --ts "1770165109.628379"
+```
+
+### Channel admin by id/name
+
+```bash
+agent-slack channel invite --channel "#general" --users "@alice,bob@example.com"
+agent-slack channel invite --channel "C0123ABCDEF" --users "U01234567"
+agent-slack channel invite --channel "#shared-room" --users "partner@vendor.com" --external
+agent-slack channel invite --channel "#shared-room" --users "partner@vendor.com" --external --allow-external-user-invites
+```
+
+## Multi-workspace ambiguity (channel names only)
+
+If you have multiple workspaces configured and your target is a channel **name** (`#general` / `general`), you must disambiguate:
+
+- pass `--workspace "https://myteam.slack.com"` (or a unique substring like `--workspace "myteam"`), or
+- set `SLACK_WORKSPACE_URL` to the same selector format
+
+Channel IDs (`C...`/`G...`/`D...`) do not require `--workspace`.

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -5,6 +5,9 @@
 # Node runtime (required by npm backend)
 node = "lts"
 
+# npm CLI tools
+"npm:agent-slack" = "latest"
+
 # Python CLI tools (pipx backend uses uv when available)
 "pipx:showboat" = "latest"
 "pipx:rodney" = "latest"


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Add `agent-slack` (Slack automation CLI) to mise global config via `npm:` backend for automatic installation
- Deploy Claude Code skill files (`SKILL.md` + 3 reference docs) to `~/.claude/skills/agent-slack/` via chezmoi
- Remove redundant `pnpm` Homebrew formula — Node (managed by mise) bundles corepack which provides pnpm on demand

## Test plan
- [ ] `chezmoi diff` shows expected changes (mise config, packages.toml, skill files)
- [ ] `chezmoi apply` deploys skill files to `~/.claude/skills/agent-slack/`
- [ ] `mise install` installs agent-slack via npm backend
- [ ] `which agent-slack` confirms binary on PATH
- [ ] `agent-slack auth whoami` runs successfully
- [ ] In Claude Code, agent-slack skill appears in available skills
- [ ] `pnpm` still works via corepack (`corepack enable && pnpm --version`)

🤖 Generated with [Claude Code](https://claude.ai/code)