### PR TITLE
feat(summarize): add default config for summarize CLI

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -4,7 +4,8 @@
         "derailed/popeye",
         "mike-engel/jwt-cli",
         "omair-inam/tap",
-        "raine/claude-history"
+        "raine/claude-history",
+        "steipete/tap"
     ]
     
     [packages.homebrew.common]
@@ -85,6 +86,7 @@
             "ripgrep",                     # Fast text search tool
             "ripgrep-all",                 # ripgrep with support for various file types
             "shellcheck",                  # Shell script linter
+            "steipete/tap/summarize",      # AI-powered text summarization CLI
             "tailscale",                   # Mesh VPN
             "tealdeer",                    # Fast tldr client
             "tree",                        # Display directory tree structure

--- a/home/dot_summarize/config.json
+++ b/home/dot_summarize/config.json
@@ -1,0 +1,8 @@
+{
+  "cli": {
+    "enabled": ["claude"],
+    "claude": {
+      "model": "sonnet"
+    }
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Add `steipete/tap` to Homebrew taps and `steipete/tap/summarize` formula to common packages for automatic installation via `chezmoi apply`
- Add chezmoi-managed `~/.summarize/config.json` configuring Claude Code (Sonnet) as the default summarization provider

## Test plan
- [ ] Run `chezmoi diff` to verify both the package list and config render correctly
- [ ] Run `chezmoi apply` (or `cmap`) to deploy
- [ ] Verify `~/.summarize/config.json` exists with expected content
- [ ] Run `summarize https://example.com` to confirm Claude Code is used as the backend

🤖 Generated with [Claude Code](https://claude.ai/code)