### PR TITLE
feat(macos): disable Dock hiding shortcut (⌥⌘D)

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_01_mac_setup.sh.tmpl
@@ -10,6 +10,17 @@ defaults write com.apple.dock tilesize -int 48
 # This is equivalent to unchecking the "Scroll direction: Natural" option in System Preferences > Trackpad.
 defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
 
+# Disable macOS keyboard shortcuts
+# To find hotkey IDs: defaults read com.apple.symbolichotkeys AppleSymbolicHotKeys
+# To add more: copy the block below, change the ID, comment, and parameters
+
+# Disable "Turn Dock hiding on/off" (⌥⌘D) — hotkey 52; conflicts with cmux "Split Browser Right"
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 52 \
+  '<dict><key>enabled</key><false/><key>value</key><dict><key>parameters</key><array><integer>100</integer><integer>2</integer><integer>1572864</integer></array><key>type</key><string>standard</string></dict></dict>'
+
+# Apply keyboard shortcut changes without logout
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+
 {{ if .work_device }}
 
 # Ensure XProtect is running and updated


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Disables the built-in macOS "Turn Dock hiding on/off" shortcut (⌥⌘D, symbolic hotkey 52) which conflicts with the cmux "Split Browser Right" shortcut
- Adds a new **Keyboard Shortcuts** section to `run_onchange_before_01_mac_setup.sh.tmpl` with inline comments for easy extension
- Includes `activateSettings -u` so changes apply without logout

## Test plan
- [ ] Run `chezmoi diff` to verify rendered output
- [ ] Run `chezmoi apply` — the `run_onchange` script fires due to content change
- [ ] Verify: `defaults read com.apple.symbolichotkeys AppleSymbolicHotKeys | grep -A 10 '"52"'` shows `enabled = 0`
- [ ] Press ⌥⌘D — should no longer toggle Dock hiding
- [ ] Verify cmux "Split Browser Right" (⌥⌘D) works without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)