### PR TITLE
chore(claude): track plugin manifests as create_ templates

### DIFF
--- a/home/dot_claude/plugins/create_known_marketplaces.json
+++ b/home/dot_claude/plugins/create_known_marketplaces.json
@@ -5,7 +5,7 @@
       "repo": "anthropics/claude-code"
     },
     "installLocation": "/Users/omair/.claude/plugins/marketplaces/claude-code-plugins",
-    "lastUpdated": "2026-02-27T14:31:15.892Z"
+    "lastUpdated": "2026-04-07T15:58:36.487Z"
   },
   "claude-plugins-official": {
     "source": {
@@ -13,7 +13,7 @@
       "repo": "anthropics/claude-plugins-official"
     },
     "installLocation": "/Users/omair/.claude/plugins/marketplaces/claude-plugins-official",
-    "lastUpdated": "2026-02-27T11:48:00.866Z"
+    "lastUpdated": "2026-04-07T14:09:14.178Z"
   },
   "superpowers-marketplace": {
     "source": {

--- a/home/dot_claude/plugins/create_private_installed_plugins.json
+++ b/home/dot_claude/plugins/create_private_installed_plugins.json
@@ -22,21 +22,21 @@
     "superpowers@claude-plugins-official": [
       {
         "scope": "user",
-        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/superpowers/4.3.1",
-        "version": "4.3.1",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0",
+        "version": "5.1.0",
         "installedAt": "2026-01-15T15:03:30.151Z",
-        "lastUpdated": "2026-02-22T13:42:50.897Z",
+        "lastUpdated": "2026-05-05T13:03:07.885Z",
         "gitCommitSha": "a08f088968d0789a44a4f5f5f7d8d6bbe46a0b44"
       }
     ],
     "commit-commands@claude-plugins-official": [
       {
         "scope": "user",
-        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/commit-commands/55b58ec6e564",
-        "version": "55b58ec6e564",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/commit-commands/unknown",
+        "version": "unknown",
         "installedAt": "2026-01-18T15:41:08.071Z",
-        "lastUpdated": "2026-02-25T11:42:41.653Z",
-        "gitCommitSha": "96276205880a60fd66bbae981f5ab568e70c4cbf"
+        "lastUpdated": "2026-05-22T18:26:26.335Z",
+        "gitCommitSha": "3449c10cd1f254c2529a4a7e96a094ef118a00a5"
       }
     ],
     "elements-of-style@superpowers-marketplace": [
@@ -52,11 +52,11 @@
     "example-skills@anthropic-agent-skills": [
       {
         "scope": "user",
-        "installPath": "/Users/omair/.claude/plugins/cache/anthropic-agent-skills/example-skills/69c0b1a06741",
-        "version": "69c0b1a06741",
+        "installPath": "/Users/omair/.claude/plugins/cache/anthropic-agent-skills/example-skills/690f15cac7f7",
+        "version": "690f15cac7f7",
         "installedAt": "2026-01-22T23:11:52.674Z",
-        "lastUpdated": "2026-01-22T23:11:52.674Z",
-        "gitCommitSha": "69c0b1a0674149f27b61b2635f935524b6add202"
+        "lastUpdated": "2026-05-21T16:56:32.552Z",
+        "gitCommitSha": "690f15cac7f7b4c055c5ab109c79ed9259934081"
       }
     ],
     "conversation-search@cc-conversation-search": [
@@ -92,11 +92,61 @@
     "document-skills@anthropic-agent-skills": [
       {
         "scope": "user",
-        "installPath": "/Users/omair/.claude/plugins/cache/anthropic-agent-skills/document-skills/69c0b1a06741",
-        "version": "69c0b1a06741",
+        "installPath": "/Users/omair/.claude/plugins/cache/anthropic-agent-skills/document-skills/690f15cac7f7",
+        "version": "690f15cac7f7",
         "installedAt": "2026-02-13T03:02:25.480Z",
-        "lastUpdated": "2026-02-13T03:02:25.480Z",
-        "gitCommitSha": "69c0b1a0674149f27b61b2635f935524b6add202"
+        "lastUpdated": "2026-05-21T16:56:32.551Z",
+        "gitCommitSha": "690f15cac7f7b4c055c5ab109c79ed9259934081"
+      }
+    ],
+    "linear@claude-plugins-official": [
+      {
+        "scope": "project",
+        "projectPath": "/Users/omair/projects/iv-living-archive",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/linear/unknown",
+        "version": "unknown",
+        "installedAt": "2026-03-10T13:09:46.978Z",
+        "lastUpdated": "2026-05-22T18:26:26.336Z",
+        "gitCommitSha": "3449c10cd1f254c2529a4a7e96a094ef118a00a5"
+      }
+    ],
+    "slack@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/slack/1.0.0",
+        "version": "1.0.0",
+        "installedAt": "2026-03-11T16:55:20.559Z",
+        "lastUpdated": "2026-03-11T16:55:20.559Z",
+        "gitCommitSha": "5a4ffe5ef353c1893eb0f1762a9071bebeeb7fde"
+      }
+    ],
+    "frontend-design@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/frontend-design/unknown",
+        "version": "unknown",
+        "installedAt": "2026-03-17T17:11:33.548Z",
+        "lastUpdated": "2026-05-22T18:26:26.334Z",
+        "gitCommitSha": "3449c10cd1f254c2529a4a7e96a094ef118a00a5"
+      }
+    ],
+    "telegram@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6",
+        "version": "0.0.6",
+        "installedAt": "2026-03-22T19:13:30.382Z",
+        "lastUpdated": "2026-04-14T20:45:53.956Z",
+        "gitCommitSha": "61c0597779bd2d670dcd4fbbf37c66aa19eb2ce6"
+      }
+    ],
+    "imessage@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/Users/omair/.claude/plugins/cache/claude-plugins-official/imessage/0.1.0",
+        "version": "0.1.0",
+        "installedAt": "2026-03-29T16:57:56.816Z",
+        "lastUpdated": "2026-03-30T23:11:05.282Z"
       }
     ]
   }


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)*

Renames the two plugin manifests to the chezmoi `create_` prefix (create-once, never clobber) and refreshes installed-plugin state (adds linear, slack, frontend-design, telegram, imessage).