### PR TITLE
feat(zsh): add Claude auto-mode aliases (cca/ccah/ccas/ccao)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Current scripts:
 ### Key Managed Files
 * `dot_zshrc.tmpl` — main shell config (Oh-My-Zsh, Powerlevel10k, mise, fzf)
 * `dot_zsh_aliases.tmpl` — aliases: chezmoi (`cm*`), kubernetes (`k*`), 1Password gh plugin
-* `dot_zsh_aliases.tmpl` — Claude Code model aliases: `cch/ccs/cco` (model shortcuts), `yoloh/yolos/yoloo` (dangerous + model)
+* `dot_zsh_aliases.tmpl` — Claude Code model aliases: `cch/ccs/cco` (model shortcuts), `yoloh/yolos/yoloo` (dangerous + model), `cca/ccah/ccas/ccao` (auto-mode + model)
 * `dot_gitconfig.tmpl` — git config with 1Password SSH signing, Beyond Compare merge tool
 * `private_dot_npmrc.tmpl` — NPM config with 1Password-sourced GitHub token
 * `dot_m2/settings.xml.tmpl` — Maven settings with GitHub packages (work only)

--- a/home/dot_zsh_aliases.tmpl
+++ b/home/dot_zsh_aliases.tmpl
@@ -9,6 +9,10 @@ alias yoloo="claude --dangerously-skip-permissions --model opus"
 alias cch="claude --model haiku"
 alias ccs="claude --model sonnet"
 alias cco="claude --model opus"
+alias cca="claude --enable-auto-mode"
+alias ccah="claude --enable-auto-mode --model haiku"
+alias ccas="claude --enable-auto-mode --model sonnet"
+alias ccao="claude --enable-auto-mode --model opus"
 
 ### Typing '.' will source ~/.zshrc
 function . {


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)*

Adds `cca` (auto-mode) and per-model `ccah/ccas/ccao` aliases; documents them in CLAUDE.md.