### PR TITLE
chore(mise): add terraform, drop agent-slack npm tool

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -5,9 +5,6 @@
 # Node runtime (required by npm backend)
 node = "lts"
 
-# npm CLI tools
-"npm:agent-slack" = "latest"
-
 # Python CLI tools (pipx backend uses uv when available)
 "pipx:google-adk" = "latest"
 "pipx:showboat" = "latest"
@@ -20,6 +17,7 @@ python = "3.13"
 # Work tools
 "npm:@arizeai/phoenix-cli" = "latest"
 java = ["temurin-24", "temurin-21"]
+terraform = "latest"
 {{ end }}
 
 [settings]


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)*

Adds `terraform = "latest"` to the mise work-tools block and removes the now-unused `npm:agent-slack` tool.