### PR TITLE
chore(git): disable 1Password commit signing

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -19,7 +19,7 @@
 	directory = *
 [push]
 	autoSetupRemote = true
-[commit]
-	gpgsign = true
-[gpg "ssh"]
-	program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
+#[commit]
+#	gpgsign = true
+#[gpg "ssh"]
+#	program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)*

Comments out the `[commit] gpgsign` / `[gpg "ssh"]` sections to match the intentionally-disabled local state.