### PR TITLE
feat(packages): add homerow cask for keyboard navigation

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -25,6 +25,7 @@
             "forklift3",                   # File manager and FTP client
             "ghostty",                     # Terminal emulator
             "google-chrome",               # Google web browser
+            "homerow",                     # Keyboard shortcuts for on-screen buttons
             "insomnia",                    # API testing and development tool
             "superkey",                    # Keyboard modifier key utility
             "intellij-idea",               # Java IDE


### PR DESCRIPTION
Adds Homerow (https://www.homerow.app/) as a common Homebrew cask so it installs on every device via chezmoi.