### PR TITLE
feat(claude): add work-review skill family

### DIFF
--- a/home/dot_claude/skills/gemini-notes/SKILL.md
+++ b/home/dot_claude/skills/gemini-notes/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: gemini-notes
+description: Find and read "Notes by Gemini" Google Doc meeting notes and transcripts via the gws CLI. Use when the user references a standup, EOD catchup, weekly review, or any Gemini-recorded meeting and you need its notes or full transcript (e.g. "read yesterday's standup notes", "get the transcript from Friday's review"). Handles locating the doc (latest / by date) and extracting both the Notes and the Transcript tabs.
+---
+
+# gemini-notes — read Gemini meeting notes & transcripts
+
+Gemini saves meeting notes as Google Docs titled `<Meeting> - <date> - Notes by
+Gemini`, with the **notes and the full transcript in two separate tabs** of the
+same document. This skill finds the right doc and extracts either tab.
+
+## 1. Find the doc
+
+List candidates with the `gws` CLI. **Always pipe `2>/dev/null`** — `gws` prints
+`Using keyring backend: keyring` to stderr, which corrupts JSON parsing:
+
+```bash
+gws drive files list --params '{"q":"name contains '"'"'Notes by Gemini'"'"' and modifiedTime > '"'"'<ISO-date>'"'"'","orderBy":"modifiedTime desc","pageSize":25,"fields":"files(id,name,modifiedTime)"}' --format json 2>/dev/null
+```
+
+**Enumerate, don't assume.** Pick the newest doc whose title matches the meeting
+you want (by meeting name + date) — never hardcode a date. This handles holidays,
+skipped meetings, and "the most recent Friday review".
+
+## 2. Extract the text
+
+Use the bundled script (handles the tab walk, nested tables, the keyring/stderr
+issue, and an old-format no-tabs fallback):
+
+```bash
+python3 ~/.claude/skills/gemini-notes/scripts/extract_gemini_doc.py <documentId> --tab all
+#   --tab notes | transcript | all
+#   --out FILE   write to a file (recommended for long transcripts)
+```
+
+For long transcripts, pass `--out` to a temp file and read that, rather than
+dumping ~50KB to stdout.
+
+## Gotchas
+
+- **Two tabs:** `Notes` and `Transcript`. The notes summary compresses away
+  detail and sometimes reverses by end-of-day — read the transcript when nuance
+  or exact commitments matter.
+- **Empty summaries happen** ("not enough conversation in a supported language");
+  the transcript is then the only record.
+- **Auth:** if extraction errors with an `invalid_rapt`/auth message, the token
+  expired — run `gws auth login`. Note `gws auth status` can look valid even when
+  the token is dead, so trust a live call.

--- a/home/dot_claude/skills/gemini-notes/scripts/extract_gemini_doc.py
+++ b/home/dot_claude/skills/gemini-notes/scripts/extract_gemini_doc.py
@@ -1,0 +1,105 @@
+# /// script
+# requires-python = ">=3.14"
+# ///
+"""Extract text from a "Notes by Gemini" Google Doc via the gws CLI.
+
+Usage:
+    extract_gemini_doc.py <documentId> [--tab notes|transcript|all] [--out PATH]
+
+Prints the requested tab(s) as plain text to stdout (or to --out).
+
+Handles the two gotchas that bite every time:
+  1. Gemini keeps the notes and the full transcript in *separate tabs* of the
+     same doc, so a plain body read misses the transcript.
+  2. `gws` prints "Using keyring backend: keyring" to stderr; we read stdout
+     only so it can't corrupt JSON parsing.
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+
+def walk(elements):
+    """Flatten a Docs body content tree (paragraphs + nested tables) to text."""
+    out = []
+    for e in elements:
+        if "paragraph" in e:
+            out.append("".join(
+                r.get("textRun", {}).get("content", "")
+                for r in e["paragraph"].get("elements", [])
+            ))
+        elif "table" in e:
+            for row in e["table"].get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    out.append(walk(cell.get("content", [])))
+    return "".join(out)
+
+
+def find_tab(tabs, title):
+    """Depth-first search for a tab by (case-insensitive) title."""
+    for t in tabs:
+        if t.get("tabProperties", {}).get("title", "").lower() == title.lower():
+            return t
+        hit = find_tab(t.get("childTabs", []), title)
+        if hit:
+            return hit
+    return None
+
+
+def tab_text(tab):
+    return walk(tab.get("documentTab", {}).get("body", {}).get("content", []))
+
+
+def fetch(doc_id):
+    params = json.dumps({"documentId": doc_id, "includeTabsContent": True})
+    p = subprocess.run(
+        ["gws", "docs", "documents", "get", "--params", params, "--format", "json"],
+        capture_output=True, text=True,
+    )
+    try:
+        return json.loads(p.stdout)
+    except json.JSONDecodeError:
+        sys.exit(
+            "ERROR: could not parse gws output. stderr:\n"
+            f"{p.stderr.strip()}\n"
+            "(If this is an auth/invalid_rapt error, run: gws auth login)"
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("document_id")
+    ap.add_argument("--tab", default="all", choices=["notes", "transcript", "all"])
+    ap.add_argument("--out", help="write to this file instead of stdout")
+    a = ap.parse_args()
+
+    doc = fetch(a.document_id)
+    tabs = doc.get("tabs", [])
+    wanted = ["Notes", "Transcript"] if a.tab == "all" else [a.tab.capitalize()]
+
+    sections = []
+    for title in wanted:
+        tab = find_tab(tabs, title)
+        if tab:
+            sections.append(f"===== {title} =====\n{tab_text(tab)}")
+        elif not tabs and title == "Notes":
+            # Older docs have no tabs; fall back to the root body.
+            sections.append(
+                "===== Notes (no tabs) =====\n"
+                + walk(doc.get("body", {}).get("content", []))
+            )
+        else:
+            sections.append(f"===== {title} =====\n(not found)")
+
+    text = "\n\n".join(sections)
+    if a.out:
+        with open(a.out, "w") as f:
+            f.write(text)
+        print(f"wrote {len(text)} chars to {a.out}")
+    else:
+        sys.stdout.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/home/dot_claude/skills/promptsmith/SKILL.md
+++ b/home/dot_claude/skills/promptsmith/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: promptsmith
+description: Turn a one-off prompt into a reusable, robust one. Use when the user wants to "make this prompt generic/reusable", "use this every day/week/Monday", "improve this prompt", or "turn this into a skill/recurring task". Applies relative dates, a verification Gate for prerequisites, enumerate-don't-assume, and a constrained output spec.
+---
+
+# promptsmith — make a prompt reusable & robust
+
+Take a single-use prompt and generalize it so it runs correctly every time.
+
+## Transformations
+
+1. **Relative, not absolute dates.** Replace fixed dates with relatives —
+   "yesterday", "the most recent Friday", "the last 7 days up to today". This is
+   the single biggest reusability lever; it also handles holidays/long weekends.
+2. **Add a Gate for hard prerequisites.** Rules are guidance; a **gate demands
+   proof of passage**. Add a Step-0 that verifies required access/state with an
+   *observable* check (run the command, show output) and STOPs with remediation
+   if it fails. **Gate only the true dependencies** — match the gate's weight to
+   what the task actually needs; an over-broad gate trains the user to click past
+   it. (See: Rules and Gates, blog.fsck.com/2026/04/07/rules-and-gates/.)
+3. **Enumerate, don't assume.** If the task targets "the meetings this week" or
+   "my open PRs", instruct it to list and select, not assume a fixed count or id.
+4. **Constrain the output, not just the input.** Replace "show me X" with the
+   shape you want: a prioritized shortlist, lead with #1, one line of why + any
+   blocker. This forces triage instead of a dump.
+5. **Bake in tool gotchas** discovered in use (e.g. pipe `2>/dev/null` for `gws`;
+   notes vs transcript live in separate doc tabs).
+6. **Add a mode/argument** if one prompt should serve several variants
+   (e.g. `daily | weekly | monday`) — pass the variant as an argument rather than
+   maintaining near-duplicate prompts.
+
+## Output
+
+- Return the rewritten prompt in a code block.
+- Add a short **what-changed** table (original → improved, with the why).
+- If the user wants it permanent, offer to persist it: a recurring task, or a
+  skill via `superpowers:writing-skills` / `skill-creator`. (If it touches
+  dotfiles, author it under chezmoi, not directly in `~`.)

--- a/home/dot_claude/skills/status-reconcile/SKILL.md
+++ b/home/dot_claude/skills/status-reconcile/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: status-reconcile
+description: Cross-reference stated commitments or plans against actual activity (Slack, Linear, GitHub, Claude session logs) to determine real status. Use for standup/weekly reviews, 1:1 or sprint-retro prep, or any "what did I say I'd do vs. what actually happened" check — surfacing items committed-but-not-done and work done-but-unreported.
+---
+
+# status-reconcile — commitments vs. reality
+
+Turn a list of commitments (meeting "next steps", a plan, a prior task list, a
+ticket set) into an honest status read by checking them against the systems of
+record.
+
+## Inputs
+
+- **Commitments** — what was promised/planned.
+- **Activity sources**, queried over the same time window:
+  - **GitHub** — `gh search prs --author <me> --updated <range>`; check **merged
+    vs closed (closed ≠ merged) vs open**, and `mergedAt`.
+  - **Linear** — issues assigned to me updated in window; `completedAt` / status.
+  - **Slack** — `from:<@me>` messages: confirmations, hand-offs, decisions.
+  - **Claude session logs** — what was actually worked on
+    (`work-review/scripts/session_activity.py`).
+
+## Method
+
+1. For each commitment assign **✅ done / 🔄 in-progress / ⛔ blocked / ❌ dropped**,
+   each with concrete evidence (PR #, issue id, message link, log line).
+2. Surface the two high-value gaps:
+   - **Committed but not done** — promised, but no corresponding activity.
+     *Absence is a signal*: e.g. a ticket that was supposed to be created simply
+     doesn't exist in Linear.
+   - **Done but unreported** — shipped work that never reached a summary (often
+     the largest/infra work; explicitly claim it).
+3. Note **recurring misses** — a commitment that reappears unfinished across
+   several days/meetings is a pattern worth a decision, not just a carry-over.
+
+## Cross-source rules
+
+- **Recency wins** on conflicts — a later EOD supersedes the morning standup.
+- **Triangulate** — one source misleads: a *closed* PR may be superseded (the
+  logs reveal a pivot), not abandoned.
+- **Verify, don't infer** — `closed ≠ merged`; an "In Progress" ticket with a
+  merged PR may actually be done.

--- a/home/dot_claude/skills/work-review/SKILL.md
+++ b/home/dot_claude/skills/work-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: work-review
+description: Review progress and plan ahead by cross-referencing Gemini meeting notes against real activity (Slack, Linear, GitHub, Claude session logs). Use for "prep my standup", "plan my day", "weekly review", "what did I get done", "plan my week", or the Monday/Friday planning sessions. Takes a MODE — daily | weekly | monday — as its argument.
+---
+
+# work-review — review & plan from meeting notes + activity
+
+Produces an honest progress read and a prioritized plan by triangulating what was
+*said* in meetings against what *actually happened* in the systems of record.
+
+## Modes (from the user's args; infer from day/context if absent)
+
+| mode | window reviewed | delivers |
+|------|-----------------|----------|
+| `daily`  | yesterday's standup (9–9:30) + EOD catchup (3:30–4) | a standup update + prioritized list for today |
+| `weekly` | this week's standups + EODs (Mon→now) | progress update by theme + prioritized goals for next week |
+| `monday` | the most recent Friday weekly progress review | a focused shortlist of today's key tasks |
+
+Cadence context: the team runs **Monday = goal-setting, Friday = accomplishments.**
+
+## Step 0 — GATE (verify access; do NOT proceed until it passes)
+
+Hard gate — produce evidence, then state `GATE PASSED` / `GATE FAILED`. If a
+required service fails, STOP and tell the user how to fix it; don't run on partial
+data.
+
+- **Google (always required):** live test, not just status —
+  `gws drive files list --params '{"pageSize":1,"fields":"files(id,name)"}' 2>/dev/null`.
+  If it 401s / `invalid_rapt`, STOP → ask the user to run `gws auth login`.
+- **Slack + Linear (required for `daily`/`weekly` cross-ref; optional for `monday`):**
+  confirm the `plugin:slack:slack` and `claude.ai Linear` MCPs respond (a trivial
+  self lookup / `get_user "me"`). If down for `monday`, skip the cross-check.
+
+## Step 1 — Gather over the mode's window
+
+**Meetings** — use the `gemini-notes` skill to find the doc(s), then extract:
+```bash
+python3 ~/.claude/skills/gemini-notes/scripts/extract_gemini_doc.py <docId> --tab all --out /tmp/<label>.txt
+```
+Enumerate every meeting in the window (`weekly` has a variable count; some days
+have no summary). Read notes **and** transcript.
+
+**Activity** over the same window:
+- **GitHub:** `gh search prs --author omairiai --updated <range>` — note merged vs **closed≠merged** vs open.
+- **Linear:** issues assigned to me, `updatedAt` in window; note `completedAt`/status.
+- **Slack:** `from:<@U0AG7202M70>` messages in window (confirmations, hand-offs, decisions).
+- **Claude logs:**
+  ```bash
+  python3 ~/.claude/skills/work-review/scripts/session_activity.py --since <YYYY-MM-DD>   # or --hours 24
+  ```
+
+## Step 2 — Reconcile
+
+Apply the **`status-reconcile`** method: map each commitment → ✅ done / 🔄
+in-progress / ⛔ blocked / ❌ dropped with evidence; then surface the two gaps —
+**committed-but-not-done** and **done-but-unreported** (the infra/reliability work
+the summaries under-credit). Recency wins on conflicts; triangulate before
+declaring status.
+
+## Step 3 — Deliver (per mode)
+
+- **daily:** a present-ready standup update (Yesterday / Today / Blockers) + a
+  prioritized action list for today; lead with the most important.
+- **weekly:** progress update grouped by workstream/theme + a prioritized set of
+  goals for next week (P0/P1/P2 + watching), blockers flagged. Offer an HTML
+  report.
+- **monday:** a focused, day-sized shortlist (≈3–6 items) of today's key tasks,
+  lead with #1, one line of why + any blocker; park the rest under "later this
+  week".
+
+## Identities & gotchas
+
+- GitHub `omairiai` · Linear/Google `omair@i.ai` · Slack `U0AG7202M70`.
+- All `gws` calls: pipe `2>/dev/null` (keyring line corrupts JSON).
+- Dates are **relative to today** — compute the window; "most recent Friday" may
+  be >3 days back after a long weekend.

--- a/home/dot_claude/skills/work-review/scripts/session_activity.py
+++ b/home/dot_claude/skills/work-review/scripts/session_activity.py
@@ -1,0 +1,104 @@
+# /// script
+# requires-python = ">=3.14"
+# ///
+"""Summarize Claude Code session logs over a recent window.
+
+Usage:
+    session_activity.py [--hours 24] [--since YYYY-MM-DD] [--root DIR]
+
+For each *main* session (subagent logs excluded) touched in the window, prints:
+time span, project, git branch, line count, and the first real user message
+(the "intent"). Useful for standup / weekly reviews and timesheets — it surfaces
+work that never reached a PR or a meeting summary.
+"""
+import argparse
+import datetime
+import glob
+import json
+import os
+
+
+def first_intent(path):
+    """First genuine user message (skip tool results, system reminders, skill preambles)."""
+    try:
+        with open(path) as fh:
+            for line in fh:
+                try:
+                    o = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if o.get("type") != "user":
+                    continue
+                c = o.get("message", {}).get("content")
+                if isinstance(c, str):
+                    t = c
+                elif isinstance(c, list):
+                    t = " ".join(
+                        p.get("text", "") for p in c
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    )
+                else:
+                    t = ""
+                t = t.strip()
+                if (t and not t.startswith("<")
+                        and "Caveat" not in t[:30]
+                        and "Base directory for this skill" not in t[:40]):
+                    return t
+    except OSError:
+        return ""
+    return ""
+
+
+def meta(path):
+    branch = first = last = None
+    n = 0
+    with open(path) as fh:
+        for line in fh:
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            n += 1
+            branch = o.get("gitBranch", branch)
+            ts = o.get("timestamp")
+            if ts:
+                first = first or ts
+                last = ts
+    return branch, first, last, n
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--hours", type=float, help="window size in hours (default 24)")
+    ap.add_argument("--since", help="ISO date; overrides --hours")
+    ap.add_argument("--root", default=os.path.expanduser("~/.claude/projects"))
+    a = ap.parse_args()
+
+    if a.since:
+        cutoff = datetime.datetime.fromisoformat(a.since).timestamp()
+    else:
+        cutoff = (datetime.datetime.now()
+                  - datetime.timedelta(hours=a.hours or 24)).timestamp()
+
+    rows = []
+    for f in glob.glob(os.path.join(a.root, "*/*.jsonl")):
+        if "/subagents/" in f:
+            continue
+        if os.path.getmtime(f) < cutoff:
+            continue
+        branch, first, last, n = meta(f)
+        proj = os.path.basename(os.path.dirname(f))
+        # Decode chezmoi/Claude's dash-encoded project path to something readable.
+        proj = proj.replace("-Users-", "~/").replace("-", "/")
+        rows.append(((first or "")[:16], (last or "")[5:16],
+                     proj[-34:], (branch or "-")[:34], n, first_intent(f)[:140]))
+
+    rows.sort()
+    for first, last, proj, branch, n, intent in rows:
+        print(f"{first}->{last} | {proj:<34} | {branch:<34} | {n:>4}l | {intent}")
+    if not rows:
+        print("(no sessions in window)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a reusable skill family for reviewing progress and planning from Gemini meeting notes cross-referenced against real activity:

- work-review: multi-mode (daily|weekly|monday) cadence skill; absorbs the former one-off monday-plan prompt. Bundles session_activity.py.
- gemini-notes: find + extract Notes/Transcript tabs from "Notes by Gemini" docs via gws. Bundles extract_gemini_doc.py (handles the two-tab layout + the keyring/stderr gotcha).
- status-reconcile: commitments vs. activity (Slack/Linear/GitHub/logs) ->
  done/in-progress/dropped + committed-but-not-done + done-but-unreported.
- promptsmith: genericize a one-off prompt (relative dates, a Gate, enumerate, constrained output).

work-review reuses gemini-notes' extractor by absolute path (deterministic DRY; skills can't call each other). Plain (non-.tmpl) files so chezmoi copies verbatim.